### PR TITLE
Use CometBFT dump consensus state endpoint

### DIFF
--- a/src/components/ConsensusStateCard.tsx
+++ b/src/components/ConsensusStateCard.tsx
@@ -1,0 +1,128 @@
+import { Card } from './Card';
+import { StatusIndicator } from './StatusIndicator';
+import { LoadingSpinner } from './LoadingSpinner';
+import { DashboardData } from '../types/cometbft';
+
+interface ConsensusStateCardProps {
+  data: DashboardData;
+}
+
+const formatPercentage = (value: number | null) => {
+  if (value === null || Number.isNaN(value)) {
+    return 'N/A';
+  }
+
+  return `${(value * 100).toFixed(1)}%`;
+};
+
+export function ConsensusStateCard({ data }: ConsensusStateCardProps) {
+  const consensusHealth = data.health.consensus;
+
+  if (data.loading) {
+    return (
+      <Card title="Consensus State">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
+          <LoadingSpinner />
+          <span style={{ color: 'var(--text-secondary)' }}>Loading consensus state...</span>
+        </div>
+      </Card>
+    );
+  }
+
+  if (!data.consensusState) {
+    return (
+      <Card title="Consensus State" glow>
+        <StatusIndicator status="error" pulse>
+          Consensus data unavailable
+        </StatusIndicator>
+        <p style={{ marginTop: 'var(--space-3)', color: 'var(--text-error)' }}>
+          Unable to load consensus information from the node.
+        </p>
+      </Card>
+    );
+  }
+
+  const { round_state } = data.consensusState.result;
+
+  return (
+    <Card title="Consensus State" glow={!consensusHealth.healthy}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <div>
+          <StatusIndicator
+            status={consensusHealth.healthy ? 'success' : 'warning'}
+            pulse={!consensusHealth.healthy}
+          >
+            {consensusHealth.healthy ? 'Consensus Healthy' : 'Consensus Issues Detected'}
+          </StatusIndicator>
+        </div>
+
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+          gap: 'var(--space-3)',
+          fontSize: 'var(--text-sm)',
+          color: 'var(--text-secondary)',
+        }}>
+          <div>
+            <strong style={{ color: 'var(--text-primary)' }}>Height</strong>
+            <br />
+            {consensusHealth.height !== null ? consensusHealth.height.toLocaleString() : 'Unknown'}
+          </div>
+          <div>
+            <strong style={{ color: 'var(--text-primary)' }}>Round</strong>
+            <br />
+            {consensusHealth.round ?? 'Unknown'}
+          </div>
+          <div>
+            <strong style={{ color: 'var(--text-primary)' }}>Step</strong>
+            <br />
+            {consensusHealth.step ?? 'Unknown'}
+          </div>
+          <div>
+            <strong style={{ color: 'var(--text-primary)' }}>Prevote Participation</strong>
+            <br />
+            {formatPercentage(consensusHealth.prevoteRatio)}
+          </div>
+          <div>
+            <strong style={{ color: 'var(--text-primary)' }}>Precommit Participation</strong>
+            <br />
+            {formatPercentage(consensusHealth.precommitRatio)}
+          </div>
+          <div>
+            <strong style={{ color: 'var(--text-primary)' }}>Round Started</strong>
+            <br />
+            {new Date(round_state.start_time).toLocaleTimeString()}
+          </div>
+        </div>
+
+        {consensusHealth.issues.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <h4 style={{
+              color: 'var(--text-warning)',
+              fontSize: 'var(--text-sm)',
+              fontWeight: 'var(--font-medium)',
+              margin: 0,
+            }}>
+              Consensus Warnings
+            </h4>
+            {consensusHealth.issues.map((issue, index) => (
+              <div
+                key={index}
+                style={{
+                  padding: 'var(--space-3)',
+                  background: 'rgba(234, 179, 8, 0.12)',
+                  border: '1px solid rgba(234, 179, 8, 0.2)',
+                  borderRadius: 'var(--radius-md)',
+                  color: 'var(--text-warning)',
+                  fontSize: 'var(--text-sm)',
+                }}
+              >
+                {issue}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -5,6 +5,7 @@ import { VersionInfoCard } from './VersionInfoCard';
 import { NetworkInfoCard } from './NetworkInfoCard';
 import { HealthAlertsCard } from './HealthAlertsCard';
 import { MempoolCard } from './MempoolCard';
+import { ConsensusStateCard } from './ConsensusStateCard';
 import { useCometBFT } from '../hooks/useCometBFT';
 
 export function Dashboard() {
@@ -38,12 +39,13 @@ export function Dashboard() {
         alignItems: 'start'
       }}>
         {/* Primary Status Cards */}
-        <div style={{ 
-          display: 'flex', 
-          flexDirection: 'column', 
-          gap: 'var(--space-6)' 
+        <div style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--space-6)'
         }}>
           <NodeStatusCard data={data} />
+          <ConsensusStateCard data={data} />
           <HealthAlertsCard data={data} />
           <MempoolCard data={data} />
         </div>

--- a/src/components/HealthAlertsCard.tsx
+++ b/src/components/HealthAlertsCard.tsx
@@ -125,6 +125,17 @@ export function HealthAlertsCard({ data }: HealthAlertsCardProps) {
                 width: '8px',
                 height: '8px',
                 borderRadius: '50%',
+                background: health.consensus.healthy ? 'var(--color-success)' : 'var(--color-warning)'
+              }} />
+              <span style={{ color: 'var(--text-secondary)' }}>
+                Consensus: {health.consensus.healthy ? 'Healthy' : 'At Risk'}
+              </span>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+              <div style={{
+                width: '8px',
+                height: '8px',
+                borderRadius: '50%',
                 background: pendingTxs > 200
                   ? 'var(--color-error)'
                   : pendingTxs > 50

--- a/src/hooks/useCometBFT.ts
+++ b/src/hooks/useCometBFT.ts
@@ -20,12 +20,22 @@ export function useCometBFT(options: UseCometBFTOptions = {}) {
     netInfo: null,
     abciInfo: null,
     mempool: null,
+    consensusState: null,
     health: {
       isOnline: false,
       isSynced: false,
       hasErrors: true,
       errorMessages: ['Initializing...'],
       lastUpdated: new Date(),
+      consensus: {
+        healthy: false,
+        height: null,
+        round: null,
+        step: null,
+        prevoteRatio: null,
+        precommitRatio: null,
+        issues: [],
+      },
     },
     loading: true,
     error: null,
@@ -49,12 +59,22 @@ export function useCometBFT(options: UseCometBFTOptions = {}) {
         ...prev,
         loading: false,
         error: error instanceof Error ? error.message : 'Failed to fetch data',
+        consensusState: null,
         health: {
           isOnline: false,
           isSynced: false,
           hasErrors: true,
           errorMessages: [error instanceof Error ? error.message : 'Failed to fetch data'],
           lastUpdated: new Date(),
+          consensus: {
+            healthy: false,
+            height: null,
+            round: null,
+            step: null,
+            prevoteRatio: null,
+            precommitRatio: null,
+            issues: [error instanceof Error ? error.message : 'Failed to fetch data'],
+          },
         }
       }));
     }

--- a/src/types/cometbft.ts
+++ b/src/types/cometbft.ts
@@ -128,12 +128,117 @@ export interface UnconfirmedTxsResponse {
   };
 }
 
+export interface ConsensusValidator {
+  address: string;
+  pub_key: {
+    type: string;
+    value: string;
+  };
+  voting_power: string;
+  proposer_priority?: string;
+}
+
+export interface ConsensusValidatorSet {
+  validators: ConsensusValidator[];
+  proposer: ConsensusValidator;
+}
+
+export interface ConsensusVoteSet {
+  round: number | string;
+  prevotes: string[];
+  prevotes_bit_array: string;
+  precommits: string[];
+  precommits_bit_array: string;
+}
+
+export interface ConsensusLastCommit {
+  votes: string[];
+  votes_bit_array: string;
+  peer_maj_23s: Record<string, unknown>;
+}
+
+export interface ConsensusRoundState {
+  height: string;
+  round: number | string;
+  step: number | string;
+  start_time: string;
+  commit_time?: string;
+  validators?: ConsensusValidatorSet;
+  proposal?: unknown;
+  proposal_block?: unknown;
+  proposal_block_parts?: unknown;
+  locked_round?: number | string;
+  locked_block?: unknown;
+  locked_block_parts?: unknown;
+  valid_round?: number | string;
+  valid_block?: unknown;
+  valid_block_parts?: unknown;
+  votes?: ConsensusVoteSet[];
+  height_vote_set?: ConsensusVoteSet[];
+  commit_round?: number | string;
+  last_commit?: ConsensusLastCommit;
+  last_validators?: ConsensusValidatorSet;
+  triggered_timeout_precommit?: boolean;
+}
+
+export interface ConsensusPeerRoundState {
+  height: string;
+  round: number | string;
+  step: number | string;
+  start_time: string;
+  proposal: boolean;
+  proposal_block_part_set_header: {
+    total: number;
+    hash: string;
+  };
+  proposal_block_parts: unknown;
+  proposal_pol_round: number;
+  proposal_pol: string;
+  prevotes: string;
+  precommits: string;
+  last_commit_round: number;
+  last_commit: string;
+  catchup_commit_round: number;
+  catchup_commit: string;
+}
+
+export interface ConsensusPeerState {
+  node_address: string;
+  peer_state: {
+    round_state: ConsensusPeerRoundState;
+    stats: {
+      votes: string;
+      block_parts: string;
+    };
+  };
+}
+
+export interface ConsensusStateResponse {
+  jsonrpc: string;
+  id: number;
+  result: {
+    round_state: ConsensusRoundState;
+    peers?: ConsensusPeerState[];
+  };
+}
+
+export interface ConsensusHealth {
+  healthy: boolean;
+  height: number | null;
+  round: number | null;
+  step: string | null;
+  prevoteRatio: number | null;
+  precommitRatio: number | null;
+  issues: string[];
+}
+
 export interface NodeHealth {
   isOnline: boolean;
   isSynced: boolean;
   hasErrors: boolean;
   errorMessages: string[];
   lastUpdated: Date;
+  consensus: ConsensusHealth;
 }
 
 export interface DashboardData {
@@ -141,6 +246,7 @@ export interface DashboardData {
   netInfo: NetInfoResponse | null;
   abciInfo: ABCIInfoResponse | null;
   mempool: UnconfirmedTxsResponse | null;
+  consensusState: ConsensusStateResponse | null;
   health: NodeHealth;
   loading: boolean;
   error: string | null;


### PR DESCRIPTION
## Summary
- fetch consensus data from the CometBFT `dump_consensus_state` endpoint to align with validator and vote details
- expand the CometBFT type definitions to cover the richer dump-consensus response including vote arrays
- update consensus health parsing to normalize numeric fields and read participation ratios from any available vote sets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da6373c9e083209a579659d60f4bfe