### PR TITLE
Guard consensus participation warnings by step

### DIFF
--- a/src/services/cometbft.ts
+++ b/src/services/cometbft.ts
@@ -194,10 +194,22 @@ export class CometBFTService {
           ? round_state.round
           : parseInt(round_state.round as string, 10);
       health.consensus.round = Number.isFinite(roundValue) ? roundValue : null;
+      const stepValue = round_state.step;
       health.consensus.step =
-        round_state.step !== undefined && round_state.step !== null
-          ? String(round_state.step)
-          : null;
+        stepValue !== undefined && stepValue !== null ? String(stepValue) : null;
+
+      const stepNumber = (() => {
+        if (typeof stepValue === 'number') {
+          return Number.isFinite(stepValue) ? stepValue : null;
+        }
+
+        if (typeof stepValue === 'string') {
+          const parsed = parseInt(stepValue, 10);
+          return Number.isNaN(parsed) ? null : parsed;
+        }
+
+        return null;
+      })();
 
       const latestBlockHeight = parseInt(status.result.sync_info.latest_block_height, 10);
       if (
@@ -221,11 +233,21 @@ export class CometBFTService {
 
       const participationThreshold = 2 / 3;
 
-      if (prevoteRatio !== null && prevoteRatio < participationThreshold) {
+      if (
+        stepNumber !== null
+        && stepNumber >= 3
+        && prevoteRatio !== null
+        && prevoteRatio < participationThreshold
+      ) {
         consensusIssues.push('Prevote participation below two-thirds threshold');
       }
 
-      if (precommitRatio !== null && precommitRatio < participationThreshold) {
+      if (
+        stepNumber !== null
+        && stepNumber >= 5
+        && precommitRatio !== null
+        && precommitRatio < participationThreshold
+      ) {
         consensusIssues.push('Precommit participation below two-thirds threshold');
       }
 


### PR DESCRIPTION
## Summary
- parse the consensus step into a numeric value with a null fallback for non-numeric states
- gate prevote and precommit participation warnings by appropriate step thresholds while keeping ratios available for display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da676674648320ba33b7394b4d05ac