### PR TITLE
Improve consensus monitoring with history and richer metrics

### DIFF
--- a/src/components/ConsensusStateCard.tsx
+++ b/src/components/ConsensusStateCard.tsx
@@ -17,6 +17,7 @@ const formatPercentage = (value: number | null) => {
 
 export function ConsensusStateCard({ data }: ConsensusStateCardProps) {
   const consensusHealth = data.health.consensus;
+  const history = data.consensusHistory;
 
   if (data.loading) {
     return (
@@ -43,6 +44,28 @@ export function ConsensusStateCard({ data }: ConsensusStateCardProps) {
   }
 
   const { round_state } = data.consensusState.result;
+  const validators = round_state.validators?.validators?.length ?? null;
+  const peerObservers = data.consensusState.result.peers?.length ?? 0;
+  const recentHistory = history.slice(-8);
+
+  const average = (values: Array<number | null>) => {
+    const valid = values.filter((value): value is number => value !== null && !Number.isNaN(value));
+    if (valid.length === 0) {
+      return null;
+    }
+    const sum = valid.reduce((total, value) => total + value, 0);
+    return sum / valid.length;
+  };
+
+  const averagePrevote = average(recentHistory.map((sample) => sample.prevoteRatio));
+  const averagePrecommit = average(recentHistory.map((sample) => sample.precommitRatio));
+
+  const normalizeRatio = (value: number | null) => {
+    if (value === null || Number.isNaN(value)) {
+      return 0;
+    }
+    return Math.max(0, Math.min(1, value));
+  };
 
   return (
     <Card title="Consensus State" glow={!consensusHealth.healthy}>
@@ -93,7 +116,102 @@ export function ConsensusStateCard({ data }: ConsensusStateCardProps) {
             <br />
             {new Date(round_state.start_time).toLocaleTimeString()}
           </div>
+          <div>
+            <strong style={{ color: 'var(--text-primary)' }}>Active Validators</strong>
+            <br />
+            {validators !== null ? validators.toLocaleString() : 'Unknown'}
+          </div>
+          <div>
+            <strong style={{ color: 'var(--text-primary)' }}>Peer Observations</strong>
+            <br />
+            {peerObservers.toLocaleString()}
+          </div>
+          <div>
+            <strong style={{ color: 'var(--text-primary)' }}>Avg Prevote (last {recentHistory.length || 1} updates)</strong>
+            <br />
+            {formatPercentage(averagePrevote)}
+          </div>
+          <div>
+            <strong style={{ color: 'var(--text-primary)' }}>Avg Precommit (last {recentHistory.length || 1} updates)</strong>
+            <br />
+            {formatPercentage(averagePrecommit)}
+          </div>
+          <div>
+            <strong style={{ color: 'var(--text-primary)' }}>Last Updated</strong>
+            <br />
+            {data.health.lastUpdated.toLocaleTimeString()}
+          </div>
         </div>
+
+        {recentHistory.length > 1 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <h4 style={{
+              color: 'var(--text-primary)',
+              fontSize: 'var(--text-sm)',
+              fontWeight: 'var(--font-medium)',
+              margin: 0,
+            }}>
+              Participation Trend
+            </h4>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: `repeat(${recentHistory.length}, minmax(0, 1fr))`,
+                gap: 'var(--space-3)',
+                alignItems: 'flex-end',
+              }}
+            >
+              {recentHistory.map((sample, index) => (
+                <div
+                  key={`${sample.timestamp}-${index}`}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 'var(--space-2)',
+                  }}
+                >
+                  <div
+                    aria-hidden
+                    style={{
+                      width: '100%',
+                      height: '72px',
+                      background: 'var(--color-surface-2)',
+                      borderRadius: 'var(--radius-sm)',
+                      display: 'flex',
+                      alignItems: 'flex-end',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: '50%',
+                        height: `${normalizeRatio(sample.prevoteRatio) * 100}%`,
+                        background: 'var(--color-primary)',
+                        opacity: 0.8,
+                      }}
+                      title={`Prevote: ${formatPercentage(sample.prevoteRatio)}`}
+                    />
+                    <div
+                      style={{
+                        width: '50%',
+                        height: `${normalizeRatio(sample.precommitRatio) * 100}%`,
+                        background: 'var(--color-accent)',
+                        opacity: 0.8,
+                      }}
+                      title={`Precommit: ${formatPercentage(sample.precommitRatio)}`}
+                    />
+                  </div>
+                  <div style={{ textAlign: 'center', fontSize: 'var(--text-xs)', color: 'var(--text-secondary)' }}>
+                    <div>{formatPercentage(sample.prevoteRatio)}</div>
+                    <div>{formatPercentage(sample.precommitRatio)}</div>
+                    <div>{new Date(sample.timestamp).toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         {consensusHealth.issues.length > 0 && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>

--- a/src/types/cometbft.ts
+++ b/src/types/cometbft.ts
@@ -232,6 +232,15 @@ export interface ConsensusHealth {
   issues: string[];
 }
 
+export interface ConsensusParticipationSample {
+  timestamp: string;
+  height: number | null;
+  round: number | null;
+  step: string | null;
+  prevoteRatio: number | null;
+  precommitRatio: number | null;
+}
+
 export interface NodeHealth {
   isOnline: boolean;
   isSynced: boolean;
@@ -250,4 +259,5 @@ export interface DashboardData {
   health: NodeHealth;
   loading: boolean;
   error: string | null;
+  consensusHistory: ConsensusParticipationSample[];
 }


### PR DESCRIPTION
## Summary
- add historical sampling and trend visualization to the consensus state card
- enhance consensus vote parsing and expose participation samples through the hook
- extend dashboard data typing to retain consensus history between refreshes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da686ebf608320b16f68f92c645189