### PR TITLE
Improve dashboard layout and editing affordance

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -39,7 +39,8 @@ export function Dashboard() {
           display: 'grid',
           gridTemplateColumns: 'repeat(auto-fit, minmax(400px, 1fr))',
           gap: 'var(--space-6)',
-          alignItems: 'start'
+          alignItems: 'start',
+          gridAutoFlow: 'dense'
         }}
       >
         <div style={{ gridColumn: '1 / -1' }}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { useState, FormEvent } from 'react';
 import { LoadingSpinner } from './LoadingSpinner';
 import { cometbftService } from '../services/cometbft';
-import { RefreshIcon, CometBFTLogo } from './Icons';
+import { RefreshIcon, CometBFTLogo, PencilIcon } from './Icons';
 
 interface HeaderProps {
   isLoading: boolean;
@@ -135,9 +135,9 @@ export function Header({ isLoading, lastUpdated, onRefresh, onNodeUrlChange }: H
             </form>
           ) : (
             <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
-              <span style={{ 
-                fontSize: 'var(--text-sm)', 
-                color: 'var(--text-muted)' 
+              <span style={{
+                fontSize: 'var(--text-sm)',
+                color: 'var(--text-muted)'
               }}>
                 Node:
               </span>
@@ -153,13 +153,18 @@ export function Header({ isLoading, lastUpdated, onRefresh, onNodeUrlChange }: H
                   fontFamily: 'var(--font-mono)',
                   cursor: 'pointer',
                   transition: 'var(--transition-fast)',
-                  maxWidth: '200px',
+                  maxWidth: '220px',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap'
+                  whiteSpace: 'nowrap',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 'var(--space-2)'
                 }}
                 title={nodeUrl}
+                aria-label={`Edit node URL ${nodeUrl}`}
               >
+                <PencilIcon size={14} style={{ flexShrink: 0 }} />
                 {nodeUrl}
               </button>
             </div>

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -102,3 +102,23 @@ export function CometBFTLogo({ size = 40, className = '', style = {} }: IconProp
     </svg>
   );
 }
+
+export function PencilIcon({ size = 16, className = '', style = {} }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      style={style}
+    >
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- ensure dashboard grid densifies to fill gaps so cards reposition intuitively
- add a pencil icon and styling updates to make the node URL button clearly editable
- expose a reusable pencil icon in the shared icon set

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da7bec9c18832092c2e65c74e0d32a