### PR TITLE
Add governance voting support with paginated proposal display

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -7,6 +7,8 @@ import { NetworkInfoCard } from './NetworkInfoCard';
 import { MempoolCard } from './MempoolCard';
 import { VersionInfoCard } from './VersionInfoCard';
 import { useCometBFT } from '../hooks/useCometBFT';
+import { useGovernance } from '../hooks/useGovernance';
+import { GovernanceCard } from './GovernanceCard';
 
 export function Dashboard() {
   const [nodeUrl, setNodeUrl] = useState('https://node.xian.org');
@@ -16,6 +18,16 @@ export function Dashboard() {
     autoRefresh: true,
     consensusRefreshInterval: 1000,
     enableConsensusRealtime: true
+  });
+
+  const validatorInfo = data.status?.result.validator_info;
+  const votingPower = validatorInfo ? Number(validatorInfo.voting_power) : 0;
+  const isValidator = Number.isFinite(votingPower) && votingPower > 0;
+
+  const governance = useGovernance({
+    nodeUrl,
+    enabled: isValidator,
+    pageSize: 5,
   });
 
   const handleNodeUrlChange = (url: string) => {
@@ -51,6 +63,9 @@ export function Dashboard() {
         <NetworkInfoCard data={data} />
         <MempoolCard data={data} />
         <VersionInfoCard data={data} />
+        <div style={{ gridColumn: '1 / -1' }}>
+          <GovernanceCard isValidator={isValidator} governance={governance} />
+        </div>
       </main>
 
       {/* Footer */}

--- a/src/components/GovernanceCard.tsx
+++ b/src/components/GovernanceCard.tsx
@@ -1,0 +1,266 @@
+import { GovernanceHookResult } from '../hooks/useGovernance';
+import { Card } from './Card';
+import { LoadingSpinner } from './LoadingSpinner';
+import { RefreshIcon } from './Icons';
+
+interface GovernanceCardProps {
+  isValidator: boolean;
+  governance: GovernanceHookResult;
+}
+
+export function GovernanceCard({ isValidator, governance }: GovernanceCardProps) {
+  if (!isValidator) {
+    return (
+      <Card title="Governance Votes">
+        <p style={{
+          margin: 0,
+          color: 'var(--text-muted)',
+          fontSize: 'var(--text-sm)',
+          lineHeight: 1.6,
+        }}>
+          This node is not currently participating as a validator. Governance data is
+          only available for validator nodes.
+        </p>
+      </Card>
+    );
+  }
+
+  const {
+    totalProposals,
+    proposals,
+    page,
+    pageSize,
+    totalPages,
+    isLoading,
+    error,
+    goToPage,
+    refresh,
+  } = governance;
+
+  const handlePrevious = () => {
+    if (page > 1) {
+      goToPage(page - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (totalPages > 0 && page < totalPages) {
+      goToPage(page + 1);
+    }
+  };
+
+  const showingFrom = totalProposals && totalProposals > 0
+    ? (page - 1) * pageSize + 1
+    : 0;
+  const showingTo = totalProposals && totalProposals > 0
+    ? (proposals.length > 0
+      ? Math.min(totalProposals, showingFrom + proposals.length - 1)
+      : showingFrom)
+    : 0;
+
+  return (
+    <Card title="Governance Votes">
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        gap: 'var(--space-3)',
+        marginBottom: 'var(--space-4)',
+        flexWrap: 'wrap',
+      }}>
+        <div>
+          <p style={{
+            margin: 0,
+            fontSize: 'var(--text-sm)',
+            color: 'var(--text-muted)',
+          }}>
+            Total proposals: {totalProposals ?? '—'}
+          </p>
+          {totalProposals && totalProposals > 0 && (
+            <p style={{
+              margin: 0,
+              fontSize: 'var(--text-xs)',
+              color: 'var(--text-secondary)',
+              marginTop: 'var(--space-1)',
+            }}>
+              Showing {showingFrom} – {showingTo} of {totalProposals}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={isLoading}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-2)',
+            padding: 'var(--space-2) var(--space-3)',
+            background: isLoading ? 'var(--bg-tertiary)' : 'var(--primary-gradient)',
+            border: 'none',
+            borderRadius: 'var(--radius-md)',
+            color: 'white',
+            fontSize: 'var(--text-sm)',
+            fontWeight: 'var(--font-medium)',
+            cursor: isLoading ? 'default' : 'pointer',
+            transition: 'var(--transition-fast)',
+          }}
+        >
+          <RefreshIcon size={16} />
+          Refresh
+        </button>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            marginBottom: 'var(--space-3)',
+            padding: 'var(--space-3)',
+            borderRadius: 'var(--radius-md)',
+            background: 'rgba(255, 59, 48, 0.1)',
+            color: 'var(--color-error)',
+            fontSize: 'var(--text-sm)',
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {isLoading && proposals.length === 0 ? (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--space-6) 0' }}>
+          <LoadingSpinner size="md" />
+        </div>
+      ) : null}
+
+      {!isLoading && (totalProposals ?? 0) === 0 && !error ? (
+        <p style={{
+          margin: 0,
+          color: 'var(--text-muted)',
+          fontSize: 'var(--text-sm)',
+        }}>
+          No governance proposals found.
+        </p>
+      ) : null}
+
+      {proposals.length > 0 && (
+        <div style={{
+          overflowX: 'auto',
+          borderRadius: 'var(--radius-md)',
+          border: '1px solid var(--border-primary)',
+          marginBottom: 'var(--space-4)',
+        }}>
+          <table style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 'var(--text-sm)',
+          }}>
+            <thead>
+              <tr style={{
+                background: 'var(--bg-tertiary)',
+                color: 'var(--text-secondary)',
+                textAlign: 'left',
+              }}>
+                <th style={{ padding: 'var(--space-3)' }}>ID</th>
+                <th style={{ padding: 'var(--space-3)' }}>Type</th>
+                <th style={{ padding: 'var(--space-3)' }}>Argument</th>
+                <th style={{ padding: 'var(--space-3)' }}>Yes</th>
+                <th style={{ padding: 'var(--space-3)' }}>No</th>
+                <th style={{ padding: 'var(--space-3)' }}>Finalized</th>
+                <th style={{ padding: 'var(--space-3)' }}>Voters</th>
+              </tr>
+            </thead>
+            <tbody>
+              {proposals.map((proposal) => (
+                <tr
+                  key={proposal.id}
+                  style={{
+                    borderTop: '1px solid var(--border-primary)',
+                    background: 'var(--bg-secondary)',
+                  }}
+                >
+                  <td style={{ padding: 'var(--space-3)', fontFamily: 'var(--font-mono)' }}>{proposal.id}</td>
+                  <td style={{ padding: 'var(--space-3)', textTransform: 'capitalize' }}>{proposal.type.replace(/_/g, ' ')}</td>
+                  <td style={{ padding: 'var(--space-3)' }}>{proposal.arg ?? '—'}</td>
+                  <td style={{ padding: 'var(--space-3)', color: 'var(--color-success)', fontWeight: 'var(--font-medium)' }}>{proposal.yes}</td>
+                  <td style={{ padding: 'var(--space-3)', color: 'var(--color-warning)', fontWeight: 'var(--font-medium)' }}>{proposal.no}</td>
+                  <td style={{ padding: 'var(--space-3)' }}>{proposal.finalized ? 'Yes' : 'No'}</td>
+                  <td style={{ padding: 'var(--space-3)' }}>
+                    <div style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 'var(--space-1)',
+                    }}>
+                      {proposal.voters.length === 0 ? (
+                        <span style={{ color: 'var(--text-muted)' }}>No votes yet</span>
+                      ) : (
+                        proposal.voters.map((voter) => (
+                          <span
+                            key={voter}
+                            style={{
+                              fontFamily: 'var(--font-mono)',
+                              fontSize: 'var(--text-xs)',
+                              wordBreak: 'break-all',
+                              color: 'var(--text-secondary)',
+                            }}
+                          >
+                            {voter}
+                          </span>
+                        ))
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 'var(--space-3)',
+          flexWrap: 'wrap',
+        }}>
+          <button
+            type="button"
+            onClick={handlePrevious}
+            disabled={page <= 1 || isLoading}
+            style={{
+              padding: 'var(--space-2) var(--space-3)',
+              borderRadius: 'var(--radius-md)',
+              border: '1px solid var(--border-primary)',
+              background: 'var(--bg-tertiary)',
+              color: 'var(--text-secondary)',
+              fontSize: 'var(--text-sm)',
+              cursor: page <= 1 || isLoading ? 'default' : 'pointer',
+            }}
+          >
+            Previous
+          </button>
+          <span style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>
+            Page {page} of {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={handleNext}
+            disabled={page >= totalPages || isLoading}
+            style={{
+              padding: 'var(--space-2) var(--space-3)',
+              borderRadius: 'var(--radius-md)',
+              border: '1px solid var(--border-primary)',
+              background: 'var(--bg-tertiary)',
+              color: 'var(--text-secondary)',
+              fontSize: 'var(--text-sm)',
+              cursor: page >= totalPages || isLoading ? 'default' : 'pointer',
+            }}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/hooks/useGovernance.ts
+++ b/src/hooks/useGovernance.ts
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { cometbftService } from '../services/cometbft';
+import { GovernanceProposal } from '../types/cometbft';
+
+interface UseGovernanceOptions {
+  nodeUrl?: string;
+  enabled?: boolean;
+  pageSize?: number;
+}
+
+interface GovernanceState {
+  totalProposals: number | null;
+  proposals: GovernanceProposal[];
+  page: number;
+  pageSize: number;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export interface GovernanceHookResult extends GovernanceState {
+  totalPages: number;
+  goToPage: (page: number) => void;
+  refresh: () => void;
+}
+
+const defaultState: GovernanceState = {
+  totalProposals: null,
+  proposals: [],
+  page: 1,
+  pageSize: 5,
+  isLoading: false,
+  error: null,
+};
+
+export function useGovernance({
+  nodeUrl,
+  enabled = true,
+  pageSize = 5,
+}: UseGovernanceOptions = {}): GovernanceHookResult {
+  const stateRef = useRef<GovernanceState>({ ...defaultState, pageSize });
+  const requestIdRef = useRef(0);
+  const totalRef = useRef<number | null>(null);
+  const [state, setState] = useState<GovernanceState>({ ...defaultState, pageSize });
+
+  const setGovernanceState = useCallback((update: GovernanceState | ((prev: GovernanceState) => GovernanceState)) => {
+    setState((prev) => {
+      const nextState = typeof update === 'function' ? (update as (value: GovernanceState) => GovernanceState)(prev) : update;
+      stateRef.current = nextState;
+      return nextState;
+    });
+  }, []);
+
+  const loadPage = useCallback(async (requestedPage: number, { forceReloadTotal = false } = {}) => {
+    if (!enabled) {
+      return;
+    }
+
+    requestIdRef.current += 1;
+    const currentRequestId = requestIdRef.current;
+
+    setGovernanceState((prev) => ({
+      ...prev,
+      isLoading: true,
+      error: null,
+    }));
+
+    try {
+      if (nodeUrl) {
+        cometbftService.setBaseUrl(nodeUrl);
+      }
+
+      if (forceReloadTotal) {
+        totalRef.current = null;
+      }
+
+      let total = totalRef.current;
+      if (total === null) {
+        total = await cometbftService.getGovernanceTotalProposals();
+        totalRef.current = total;
+      }
+
+      if (requestIdRef.current !== currentRequestId) {
+        return;
+      }
+
+      if (!total || total <= 0) {
+        setGovernanceState({
+          totalProposals: 0,
+          proposals: [],
+          page: 1,
+          pageSize,
+          isLoading: false,
+          error: null,
+        });
+        return;
+      }
+
+      const maxPage = Math.max(1, Math.ceil(total / pageSize));
+      const safePage = Math.min(Math.max(1, requestedPage), maxPage);
+      const startId = (safePage - 1) * pageSize + 1;
+      const endId = Math.min(total, startId + pageSize - 1);
+      const proposals = await cometbftService.getGovernanceProposalsRange(startId, endId);
+
+      if (requestIdRef.current !== currentRequestId) {
+        return;
+      }
+
+      setGovernanceState({
+        totalProposals: total,
+        proposals,
+        page: safePage,
+        pageSize,
+        isLoading: false,
+        error: null,
+      });
+    } catch (error) {
+      if (requestIdRef.current !== currentRequestId) {
+        return;
+      }
+
+      const message = error instanceof Error ? error.message : 'Failed to load governance proposals';
+      setGovernanceState((prev) => ({
+        ...prev,
+        isLoading: false,
+        error: message,
+      }));
+    }
+  }, [enabled, nodeUrl, pageSize, setGovernanceState]);
+
+  const goToPage = useCallback((page: number) => {
+    if (!enabled) {
+      return;
+    }
+    loadPage(page);
+  }, [enabled, loadPage]);
+
+  const refresh = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+    const currentPage = stateRef.current.page || 1;
+    loadPage(currentPage, { forceReloadTotal: true });
+  }, [enabled, loadPage]);
+
+  useEffect(() => {
+    totalRef.current = null;
+    requestIdRef.current += 1;
+
+    if (!enabled) {
+      setGovernanceState({
+        totalProposals: null,
+        proposals: [],
+        page: 1,
+        pageSize,
+        isLoading: false,
+        error: null,
+      });
+      return;
+    }
+
+    setGovernanceState({
+      totalProposals: null,
+      proposals: [],
+      page: 1,
+      pageSize,
+      isLoading: true,
+      error: null,
+    });
+
+    loadPage(1);
+  }, [enabled, nodeUrl, pageSize, loadPage, setGovernanceState]);
+
+  useEffect(() => () => {
+    requestIdRef.current += 1;
+  }, []);
+
+  const totalPages = useMemo(() => {
+    if (!state.totalProposals || state.totalProposals <= 0) {
+      return 0;
+    }
+    return Math.max(1, Math.ceil(state.totalProposals / state.pageSize));
+  }, [state.totalProposals, state.pageSize]);
+
+  return {
+    ...state,
+    totalPages,
+    goToPage,
+    refresh,
+  };
+}

--- a/src/types/cometbft.ts
+++ b/src/types/cometbft.ts
@@ -128,6 +128,24 @@ export interface UnconfirmedTxsResponse {
   };
 }
 
+export interface ABCIQueryResponse {
+  jsonrpc: string;
+  id: number;
+  result: {
+    response: {
+      code: number;
+      log: string;
+      info: string;
+      index: string;
+      key: string | null;
+      value: string | null;
+      proofOps: unknown;
+      height: string;
+      codespace: string;
+    };
+  };
+}
+
 export interface ConsensusValidator {
   address: string;
   pub_key: {
@@ -248,6 +266,23 @@ export interface NodeHealth {
   errorMessages: string[];
   lastUpdated: Date;
   consensus: ConsensusHealth;
+}
+
+export interface GovernanceProposal {
+  id: number;
+  yes: number;
+  no: number;
+  type: string;
+  arg: number | string | null;
+  voters: string[];
+  finalized: boolean;
+}
+
+export interface GovernancePage {
+  totalProposals: number;
+  proposals: GovernanceProposal[];
+  page: number;
+  pageSize: number;
 }
 
 export interface DashboardData {


### PR DESCRIPTION
## Summary
- add governance-specific CometBFT service helpers to query proposal totals and individual vote data
- introduce a reusable governance hook and card that paginate proposals for validator nodes
- surface the governance card on the dashboard when the connected node has validator voting power

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daa72898408320bdc67f0d90948807