### PR TITLE
Refine dashboard layout

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -35,52 +35,86 @@ export function Dashboard() {
   };
 
   return (
-    <div style={{ minHeight: '100vh', background: 'var(--bg-primary)' }}>
+    <div className="dashboard-container">
       <Header
         isLoading={isLoading}
         lastUpdated={data.health.lastUpdated}
         onRefresh={refresh}
         onNodeUrlChange={handleNodeUrlChange}
       />
-      
-      <main
-        style={{
-          maxWidth: '1400px',
-          margin: '0 auto',
-          padding: 'var(--space-6)',
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(400px, 1fr))',
-          gap: 'var(--space-6)',
-          alignItems: 'start',
-          gridAutoFlow: 'dense'
-        }}
-      >
-        <div style={{ gridColumn: '1 / -1' }}>
-          <NodeStatusCard data={data} />
-        </div>
-        <HealthAlertsCard data={data} />
-        <ConsensusStateCard data={data} />
-        <NetworkInfoCard data={data} />
-        <MempoolCard data={data} />
-        <VersionInfoCard data={data} />
-        <div style={{ gridColumn: '1 / -1' }}>
-          <GovernanceCard isValidator={isValidator} governance={governance} />
-        </div>
+
+      <main className="dashboard-content">
+        <section className="dashboard-section">
+          <div className="dashboard-section__header">
+            <h2 className="dashboard-section__title">Node overview</h2>
+            <p className="dashboard-section__subtitle">
+              Current validator identity, peers and uptime
+            </p>
+          </div>
+          <div className="dashboard-grid dashboard-grid--single">
+            <div className="dashboard-item">
+              <NodeStatusCard data={data} />
+            </div>
+          </div>
+        </section>
+
+        <section className="dashboard-section">
+          <div className="dashboard-section__header">
+            <h2 className="dashboard-section__title">Health &amp; consensus</h2>
+            <p className="dashboard-section__subtitle">
+              Live heartbeat, block production and participation metrics
+            </p>
+          </div>
+          <div className="dashboard-grid">
+            <div className="dashboard-item">
+              <HealthAlertsCard data={data} />
+            </div>
+            <div className="dashboard-item">
+              <ConsensusStateCard data={data} />
+            </div>
+          </div>
+        </section>
+
+        <section className="dashboard-section">
+          <div className="dashboard-section__header">
+            <h2 className="dashboard-section__title">Network activity</h2>
+            <p className="dashboard-section__subtitle">
+              Peer connectivity, throughput and mempool insights
+            </p>
+          </div>
+          <div className="dashboard-grid">
+            <div className="dashboard-item">
+              <NetworkInfoCard data={data} />
+            </div>
+            <div className="dashboard-item">
+              <MempoolCard data={data} />
+            </div>
+          </div>
+        </section>
+
+        <section className="dashboard-section">
+          <div className="dashboard-section__header">
+            <h2 className="dashboard-section__title">Version &amp; governance</h2>
+            <p className="dashboard-section__subtitle">
+              Release alignment and validator decision tracking
+            </p>
+          </div>
+          <div className="dashboard-grid">
+            <div className="dashboard-item">
+              <VersionInfoCard data={data} />
+            </div>
+            <div className="dashboard-item dashboard-item--wide">
+              <GovernanceCard isValidator={isValidator} governance={governance} />
+            </div>
+          </div>
+        </section>
       </main>
 
-      {/* Footer */}
-      <footer style={{
-        borderTop: '1px solid var(--border-primary)',
-        padding: 'var(--space-4)',
-        textAlign: 'center',
-        color: 'var(--text-muted)',
-        fontSize: 'var(--text-sm)',
-        background: 'var(--bg-secondary)'
-      }}>
+      <footer className="dashboard-footer">
         <p>
           Xian Node Dashboard - Real-time monitoring for CometBFT 0.38.12 nodes
         </p>
-        <p style={{ marginTop: 'var(--space-2)', fontSize: 'var(--text-xs)' }}>
+        <p className="dashboard-footer__meta">
           Auto-refresh every 5 seconds • Built with React & TypeScript
         </p>
       </footer>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -200,6 +200,100 @@ body {
   animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
+/* Dashboard layout */
+.dashboard-container {
+  min-height: 100vh;
+  background: var(--bg-primary);
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-content {
+  max-width: 1400px;
+  margin: 0 auto;
+  width: 100%;
+  padding: var(--space-8) var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.dashboard-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.dashboard-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.dashboard-section__title {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-semibold);
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+}
+
+.dashboard-section__subtitle {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: var(--space-6);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.dashboard-grid--single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.dashboard-item {
+  min-width: 0;
+}
+
+.dashboard-item--wide {
+  grid-column: 1 / -1;
+}
+
+.dashboard-footer {
+  border-top: 1px solid var(--border-primary);
+  padding: var(--space-4);
+  text-align: center;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  background: var(--bg-secondary);
+  margin-top: auto;
+}
+
+.dashboard-footer__meta {
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+}
+
+@media (max-width: 1024px) {
+  .dashboard-content {
+    padding: var(--space-6) var(--space-4);
+    gap: var(--space-6);
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard-section__title {
+    font-size: var(--text-xl);
+  }
+
+  .dashboard-section__subtitle {
+    font-size: var(--text-xs);
+  }
+}
+
 @keyframes pulse {
   0%, 100% {
     opacity: 1;


### PR DESCRIPTION
## Summary
- reorganize the dashboard into themed sections with supporting descriptions for each group of cards
- add layout utility classes to globals.css to provide consistent spacing, responsive grids, and footer styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daabe687cc8320809aec89d97dadcb