### PR TITLE
Adjust governance argument alignment on desktop

### DIFF
--- a/src/components/GovernanceCard.tsx
+++ b/src/components/GovernanceCard.tsx
@@ -243,7 +243,12 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
                 >
                   <td style={{ padding: 'var(--space-3)', fontFamily: 'var(--font-mono)' }}>{proposal.id}</td>
                   <td style={{ padding: 'var(--space-3)', textTransform: 'capitalize' }}>{proposal.type.replace(/_/g, ' ')}</td>
-                  <td style={{ padding: 'var(--space-3)', verticalAlign: 'top' }}>
+                  <td
+                    style={{
+                      padding: 'var(--space-3)',
+                      verticalAlign: 'middle',
+                    }}
+                  >
                     {renderProposalArgument(proposal.arg)}
                   </td>
                   <td style={{ padding: 'var(--space-3)', color: 'var(--color-success)', fontWeight: 'var(--font-medium)' }}>{proposal.yes}</td>


### PR DESCRIPTION
## Summary
- update governance table argument cell styling to vertically center short arguments on desktop

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab2bb40008320a06e490ba6e626ff