### PR TITLE
Refactor governance wallet UX with modal and tabs

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,16 +9,19 @@ import { VersionInfoCard } from './VersionInfoCard';
 import { useCometBFT } from '../hooks/useCometBFT';
 import { useGovernance } from '../hooks/useGovernance';
 import { GovernanceCard } from './GovernanceCard';
+import { useWallet } from '../hooks/useWallet';
 
 export function Dashboard() {
   const [nodeUrl, setNodeUrl] = useState('https://node.xian.org');
-  const { data, refresh, isLoading } = useCometBFT({
+  const { data } = useCometBFT({
     nodeUrl,
     refreshInterval: 5000,
     autoRefresh: true,
     consensusRefreshInterval: 1000,
     enableConsensusRealtime: true
   });
+
+  const wallet = useWallet();
 
   const validatorInfo = data.status?.result.validator_info;
   const votingPower = validatorInfo ? Number(validatorInfo.voting_power) : 0;
@@ -37,10 +40,12 @@ export function Dashboard() {
   return (
     <div className="dashboard-container">
       <Header
-        isLoading={isLoading}
-        lastUpdated={data.health.lastUpdated}
-        onRefresh={refresh}
         onNodeUrlChange={handleNodeUrlChange}
+        walletInfo={wallet.walletInfo}
+        isConnectingWallet={wallet.isConnecting}
+        onConnectWallet={wallet.connect}
+        walletError={wallet.error}
+        onClearWalletError={wallet.clearError}
       />
 
       <main className="dashboard-content">
@@ -104,7 +109,15 @@ export function Dashboard() {
               <VersionInfoCard data={data} />
             </div>
             <div className="dashboard-item dashboard-item--wide">
-              <GovernanceCard isValidator={isValidator} governance={governance} />
+              <GovernanceCard
+                isValidator={isValidator}
+                governance={governance}
+                walletInfo={wallet.walletInfo}
+                isConnectingWallet={wallet.isConnecting}
+                onConnectWallet={wallet.connect}
+                walletError={wallet.error}
+                clearWalletError={wallet.clearError}
+              />
             </div>
           </div>
         </section>

--- a/src/components/GovernanceCard.tsx
+++ b/src/components/GovernanceCard.tsx
@@ -4,20 +4,20 @@ import { Card } from './Card';
 import { LoadingSpinner } from './LoadingSpinner';
 import { RefreshIcon } from './Icons';
 import XianWalletUtils from '../services/xianWalletUtils';
+import { ConnectedWalletInfo } from '../hooks/useWallet';
+import { Modal } from './Modal';
 
 interface GovernanceCardProps {
   isValidator: boolean;
   governance: GovernanceHookResult;
+  walletInfo: ConnectedWalletInfo | null;
+  isConnectingWallet: boolean;
+  onConnectWallet: () => void;
+  walletError: string | null;
+  clearWalletError: () => void;
 }
 
 type ProposalArgument = GovernanceHookResult['proposals'][number]['arg'];
-
-interface ConnectedWalletInfo {
-  address: string;
-  truncatedAddress?: string;
-  locked?: boolean;
-  chainId?: string;
-}
 
 function renderProposalArgument(arg: ProposalArgument): ReactNode {
   if (arg === null || typeof arg === 'undefined') {
@@ -90,11 +90,16 @@ function parseProposalArgument(value: string): unknown {
   return trimmed;
 }
 
-export function GovernanceCard({ isValidator, governance }: GovernanceCardProps) {
+export function GovernanceCard({
+  isValidator,
+  governance,
+  walletInfo,
+  isConnectingWallet,
+  onConnectWallet,
+  walletError,
+  clearWalletError,
+}: GovernanceCardProps) {
   const [isMobile, setIsMobile] = useState(false);
-  const [walletInfo, setWalletInfo] = useState<ConnectedWalletInfo | null>(null);
-  const [walletError, setWalletError] = useState<string | null>(null);
-  const [isConnectingWallet, setIsConnectingWallet] = useState(false);
   const [proposalType, setProposalType] = useState('');
   const [proposalArgument, setProposalArgument] = useState('');
   const [proposalError, setProposalError] = useState<string | null>(null);
@@ -103,6 +108,8 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
   const [voteStatus, setVoteStatus] = useState<{ proposalId: number; direction: 'yes' | 'no' } | null>(null);
   const [voteMessage, setVoteMessage] = useState<string | null>(null);
   const [voteError, setVoteError] = useState<string | null>(null);
+  const [isProposalModalOpen, setIsProposalModalOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<'all' | 'active' | 'finalized'>('all');
 
   const {
     totalProposals,
@@ -140,29 +147,39 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
     [walletInfo],
   );
 
-  const handleConnectWallet = useCallback(async () => {
-    setWalletError(null);
+  const openProposalModal = useCallback(() => {
+    setProposalError(null);
+    setProposalSuccess(null);
+    clearWalletError();
+    setIsProposalModalOpen(true);
+  }, [clearWalletError]);
+
+  const closeProposalModal = useCallback(() => {
+    if (isSubmittingProposal) {
+      return;
+    }
+
+    setIsProposalModalOpen(false);
+    setProposalError(null);
+    setProposalType('');
+    setProposalArgument('');
+  }, [isSubmittingProposal]);
+
+  const handleConnectWallet = useCallback(() => {
+    clearWalletError();
     setVoteMessage(null);
     setVoteError(null);
     setProposalSuccess(null);
-
-    try {
-      setIsConnectingWallet(true);
-      const info = await XianWalletUtils.requestWalletInfo();
-      setWalletInfo(info);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to connect wallet';
-      setWalletError(message);
-    } finally {
-      setIsConnectingWallet(false);
-    }
-  }, []);
+    setProposalError(null);
+    onConnectWallet();
+  }, [clearWalletError, onConnectWallet]);
 
   const handleSubmitProposal = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       setProposalError(null);
       setProposalSuccess(null);
+      clearWalletError();
 
       if (!walletInfo) {
         setProposalError('Connect your wallet before creating a proposal.');
@@ -191,21 +208,23 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
         setProposalType('');
         setProposalArgument('');
         setProposalSuccess('Proposal submitted successfully.');
+        setIsProposalModalOpen(false);
         refresh();
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Failed to submit proposal';
+      } catch (submitError) {
+        const message = submitError instanceof Error ? submitError.message : 'Failed to submit proposal';
         setProposalError(message);
       } finally {
         setIsSubmittingProposal(false);
       }
     },
-    [proposalArgument, proposalType, refresh, walletInfo],
+    [clearWalletError, proposalArgument, proposalType, refresh, walletInfo],
   );
 
   const handleVote = useCallback(
     async (proposalId: number, direction: 'yes' | 'no') => {
       setVoteError(null);
       setVoteMessage(null);
+      clearWalletError();
 
       if (!walletInfo) {
         setVoteError('Connect your wallet before voting.');
@@ -225,14 +244,14 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
 
         setVoteMessage(`Vote submitted for proposal #${proposalId}.`);
         refresh();
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Failed to submit vote';
+      } catch (voteErr) {
+        const message = voteErr instanceof Error ? voteErr.message : 'Failed to submit vote';
         setVoteError(message);
       } finally {
         setVoteStatus(null);
       }
     },
-    [refresh, walletInfo],
+    [clearWalletError, refresh, walletInfo],
   );
 
   if (!isValidator) {
@@ -263,207 +282,261 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
     }
   };
 
-  const showingFrom = proposals.length > 0
-    ? proposals[0].id
+  const filteredProposals = useMemo(() => {
+    if (activeTab === 'active') {
+      return proposals.filter((proposal) => !proposal.finalized);
+    }
+
+    if (activeTab === 'finalized') {
+      return proposals.filter((proposal) => proposal.finalized);
+    }
+
+    return proposals;
+  }, [activeTab, proposals]);
+
+  const activeCount = useMemo(
+    () => proposals.filter((proposal) => !proposal.finalized).length,
+    [proposals],
+  );
+
+  const finalizedCount = useMemo(
+    () => proposals.filter((proposal) => proposal.finalized).length,
+    [proposals],
+  );
+
+  const tabOptions = useMemo(
+    () => [
+      { key: 'all' as const, label: `All (${proposals.length})` },
+      { key: 'active' as const, label: `Active (${activeCount})` },
+      { key: 'finalized' as const, label: `Finalized (${finalizedCount})` },
+    ],
+    [activeCount, finalizedCount, proposals.length],
+  );
+
+  const showingFrom = filteredProposals.length > 0
+    ? filteredProposals[0].id
     : 0;
-  const showingTo = proposals.length > 0
-    ? proposals[proposals.length - 1].id
+  const showingTo = filteredProposals.length > 0
+    ? filteredProposals[filteredProposals.length - 1].id
     : 0;
 
   return (
     <Card title="Governance Votes">
-      <div style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 'var(--space-3)',
-        marginBottom: 'var(--space-4)',
-      }}>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 'var(--space-2)',
-            padding: 'var(--space-3)',
-            borderRadius: 'var(--radius-md)',
-            border: '1px solid var(--border-primary)',
-            background: 'var(--bg-secondary)',
-          }}
-        >
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 'var(--space-3)', flexWrap: 'wrap' }}>
-            <div style={{ display: 'flex', flexDirection: 'column' }}>
-              <span style={{ fontSize: 'var(--text-sm)', color: 'var(--text-secondary)', fontWeight: 'var(--font-medium)' }}>
-                Wallet
-              </span>
-              {walletInfo ? (
-                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--text-sm)' }}>
-                  {walletInfo.truncatedAddress ?? walletInfo.address}
-                </span>
-              ) : (
-                <span style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>No wallet connected</span>
-              )}
-              {walletInfo?.locked ? (
-                <span style={{ fontSize: 'var(--text-xs)', color: 'var(--color-warning)' }}>
-                  Wallet is locked. Please unlock it before signing transactions.
-                </span>
-              ) : null}
-            </div>
-            <button
-              type="button"
-              onClick={handleConnectWallet}
-              disabled={isConnectingWallet}
-              style={{
-                padding: 'var(--space-2) var(--space-3)',
-                borderRadius: 'var(--radius-md)',
-                border: '1px solid var(--border-primary)',
-                background: 'var(--bg-tertiary)',
-                color: 'var(--text-secondary)',
-                fontSize: 'var(--text-sm)',
-                fontWeight: 'var(--font-medium)',
-                cursor: isConnectingWallet ? 'default' : 'pointer',
-              }}
-            >
-              {isConnectingWallet ? 'Connecting…' : walletInfo ? 'Reconnect Wallet' : 'Connect Wallet'}
-            </button>
-          </div>
-          {walletError ? (
-            <span style={{ color: 'var(--color-error)', fontSize: 'var(--text-sm)' }}>{walletError}</span>
-          ) : null}
-          {voteMessage ? (
-            <span style={{ color: 'var(--color-success)', fontSize: 'var(--text-sm)' }}>{voteMessage}</span>
-          ) : null}
-          {voteError ? (
-            <span style={{ color: 'var(--color-error)', fontSize: 'var(--text-sm)' }}>{voteError}</span>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          flexWrap: 'wrap',
+          gap: 'var(--space-4)',
+          marginBottom: 'var(--space-4)',
+        }}
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+          <span style={{ fontSize: 'var(--text-sm)', fontWeight: 'var(--font-medium)', color: 'var(--text-secondary)' }}>
+            Wallet
+          </span>
+          <span
+            style={{
+              fontSize: 'var(--text-sm)',
+              color: walletInfo ? 'var(--text-secondary)' : 'var(--text-muted)',
+              fontFamily: walletInfo ? 'var(--font-mono)' : 'inherit',
+            }}
+          >
+            {walletInfo ? (walletInfo.truncatedAddress ?? walletInfo.address) : 'No wallet connected'}
+          </span>
+          {walletInfo?.locked ? (
+            <span style={{ fontSize: 'var(--text-xs)', color: 'var(--color-warning)' }}>
+              Wallet is locked. Please unlock it before signing transactions.
+            </span>
           ) : null}
         </div>
-
-        <form
-          onSubmit={handleSubmitProposal}
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 'var(--space-2)',
-            padding: 'var(--space-3)',
-            borderRadius: 'var(--radius-md)',
-            border: '1px solid var(--border-primary)',
-            background: 'var(--bg-secondary)',
-          }}
-        >
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 'var(--space-2)' }}>
-            <span style={{ fontSize: 'var(--text-sm)', fontWeight: 'var(--font-medium)', color: 'var(--text-secondary)' }}>
-              Create Proposal
-            </span>
-            <button
-              type="submit"
-              disabled={isSubmittingProposal || !walletInfo || walletInfo.locked}
-              style={{
-                padding: 'var(--space-2) var(--space-3)',
-                borderRadius: 'var(--radius-md)',
-                border: 'none',
-                background: 'var(--primary-gradient)',
-                color: 'white',
-                fontSize: 'var(--text-sm)',
-                fontWeight: 'var(--font-medium)',
-                cursor: isSubmittingProposal || !walletInfo || walletInfo.locked ? 'default' : 'pointer',
-                opacity: isSubmittingProposal || !walletInfo || walletInfo.locked ? 0.7 : 1,
-              }}
-            >
-              {isSubmittingProposal ? 'Submitting…' : 'Submit Proposal'}
-            </button>
-          </div>
-          <label style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
-            <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Proposal Type</span>
-            <input
-              type="text"
-              value={proposalType}
-              onChange={(event) => setProposalType(event.target.value)}
-              placeholder="e.g. add_member"
-              style={{
-                padding: 'var(--space-2)',
-                borderRadius: 'var(--radius-sm)',
-                border: '1px solid var(--border-primary)',
-                background: 'var(--bg-tertiary)',
-                color: 'var(--text-primary)',
-                fontSize: 'var(--text-sm)',
-              }}
-            />
-          </label>
-          <label style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
-            <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Proposal Argument</span>
-            <textarea
-              value={proposalArgument}
-              onChange={(event) => setProposalArgument(event.target.value)}
-              placeholder="Argument value (text, number, or JSON)"
-              rows={3}
-              style={{
-                padding: 'var(--space-2)',
-                borderRadius: 'var(--radius-sm)',
-                border: '1px solid var(--border-primary)',
-                background: 'var(--bg-tertiary)',
-                color: 'var(--text-primary)',
-                fontSize: 'var(--text-sm)',
-                resize: 'vertical',
-              }}
-            />
-          </label>
-          {proposalError ? (
-            <span style={{ color: 'var(--color-error)', fontSize: 'var(--text-sm)' }}>{proposalError}</span>
-          ) : null}
-          {proposalSuccess ? (
-            <span style={{ color: 'var(--color-success)', fontSize: 'var(--text-sm)' }}>{proposalSuccess}</span>
-          ) : null}
-        </form>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 'var(--space-2)', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            onClick={handleConnectWallet}
+            disabled={isConnectingWallet}
+            style={{
+              padding: 'var(--space-2) var(--space-3)',
+              borderRadius: 'var(--radius-md)',
+              border: '1px solid var(--border-primary)',
+              background: 'var(--bg-tertiary)',
+              color: 'var(--text-secondary)',
+              fontSize: 'var(--text-sm)',
+              fontWeight: 'var(--font-medium)',
+              cursor: isConnectingWallet ? 'default' : 'pointer',
+            }}
+          >
+            {isConnectingWallet ? 'Connecting…' : walletInfo ? 'Reconnect Wallet' : 'Connect Wallet'}
+          </button>
+          <button
+            type="button"
+            onClick={openProposalModal}
+            disabled={!walletInfo || walletInfo.locked}
+            style={{
+              padding: 'var(--space-2) var(--space-3)',
+              borderRadius: 'var(--radius-md)',
+              border: 'none',
+              background: 'var(--primary-gradient)',
+              color: 'white',
+              fontSize: 'var(--text-sm)',
+              fontWeight: 'var(--font-medium)',
+              cursor: !walletInfo || walletInfo.locked ? 'default' : 'pointer',
+              opacity: !walletInfo || walletInfo.locked ? 0.7 : 1,
+            }}
+          >
+            New Proposal
+          </button>
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={isLoading}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-2)',
+              padding: 'var(--space-2) var(--space-3)',
+              borderRadius: 'var(--radius-md)',
+              border: '1px solid var(--border-primary)',
+              background: 'var(--bg-tertiary)',
+              color: 'var(--text-secondary)',
+              fontSize: 'var(--text-sm)',
+              fontWeight: 'var(--font-medium)',
+              cursor: isLoading ? 'default' : 'pointer',
+            }}
+          >
+            {isLoading ? (
+              <>
+                <LoadingSpinner size="sm" />
+                Refreshing…
+              </>
+            ) : (
+              <>
+                <RefreshIcon size={16} />
+                Refresh
+              </>
+            )}
+          </button>
+        </div>
       </div>
 
-      <div style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        gap: 'var(--space-3)',
-        marginBottom: 'var(--space-4)',
-        flexWrap: 'wrap',
-      }}>
-        <div>
-          <p style={{
-            margin: 0,
-            fontSize: 'var(--text-sm)',
-            color: 'var(--text-muted)',
-          }}>
-            Total proposals: {totalProposals ?? '—'}
-          </p>
-          {totalProposals && totalProposals > 0 && proposals.length > 0 && (
-
-            <p style={{
-              margin: 0,
-              fontSize: 'var(--text-xs)',
-              color: 'var(--text-secondary)',
-              marginTop: 'var(--space-1)',
-            }}>
-              Showing {showingFrom} – {showingTo} of {totalProposals}
-            </p>
-          )}
-        </div>
-        <button
-          type="button"
-          onClick={refresh}
-          disabled={isLoading}
+      {walletError ? (
+        <div
           style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 'var(--space-2)',
+            marginBottom: 'var(--space-3)',
             padding: 'var(--space-2) var(--space-3)',
-            background: isLoading ? 'var(--bg-tertiary)' : 'var(--primary-gradient)',
-            border: 'none',
             borderRadius: 'var(--radius-md)',
-            color: 'white',
+            background: 'rgba(255, 71, 87, 0.12)',
+            color: 'var(--color-error)',
             fontSize: 'var(--text-sm)',
-            fontWeight: 'var(--font-medium)',
-            cursor: isLoading ? 'default' : 'pointer',
-            transition: 'var(--transition-fast)',
           }}
         >
-          <RefreshIcon size={16} />
-          Refresh
-        </button>
+          {walletError}
+        </div>
+      ) : null}
+
+      {proposalSuccess ? (
+        <div
+          style={{
+            marginBottom: 'var(--space-3)',
+            padding: 'var(--space-2) var(--space-3)',
+            borderRadius: 'var(--radius-md)',
+            background: 'rgba(52, 199, 89, 0.12)',
+            color: 'var(--color-success)',
+            fontSize: 'var(--text-sm)',
+          }}
+        >
+          {proposalSuccess}
+        </div>
+      ) : null}
+
+      {voteMessage ? (
+        <div
+          style={{
+            marginBottom: 'var(--space-3)',
+            padding: 'var(--space-2) var(--space-3)',
+            borderRadius: 'var(--radius-md)',
+            background: 'rgba(52, 199, 89, 0.12)',
+            color: 'var(--color-success)',
+            fontSize: 'var(--text-sm)',
+          }}
+        >
+          {voteMessage}
+        </div>
+      ) : null}
+
+      {voteError ? (
+        <div
+          style={{
+            marginBottom: 'var(--space-3)',
+            padding: 'var(--space-2) var(--space-3)',
+            borderRadius: 'var(--radius-md)',
+            background: 'rgba(255, 71, 87, 0.12)',
+            color: 'var(--color-error)',
+            fontSize: 'var(--text-sm)',
+          }}
+        >
+          {voteError}
+        </div>
+      ) : null}
+
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: 'var(--space-3)',
+          flexWrap: 'wrap',
+          marginBottom: 'var(--space-3)',
+        }}
+      >
+        <div>
+          <p style={{ margin: 0, fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>
+            Total proposals: {totalProposals ?? '—'}
+          </p>
+          {totalProposals && totalProposals > 0 && filteredProposals.length > 0 ? (
+            <p
+              style={{
+                margin: 0,
+                fontSize: 'var(--text-xs)',
+                color: 'var(--text-secondary)',
+                marginTop: 'var(--space-1)',
+              }}
+            >
+              Showing IDs {showingFrom} – {showingTo}
+            </p>
+          ) : null}
+        </div>
+        <div style={{ display: 'flex', gap: 'var(--space-3)', fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+          <span>Active: {activeCount}</span>
+          <span>Finalized: {finalizedCount}</span>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: 'var(--space-2)', flexWrap: 'wrap', marginBottom: 'var(--space-3)' }}>
+        {tabOptions.map(({ key, label }) => {
+          const isActive = activeTab === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setActiveTab(key)}
+              style={{
+                padding: 'var(--space-2) var(--space-3)',
+                borderRadius: 'var(--radius-md)',
+                border: isActive ? 'none' : '1px solid var(--border-primary)',
+                background: isActive ? 'var(--primary-gradient)' : 'var(--bg-secondary)',
+                color: isActive ? 'white' : 'var(--text-secondary)',
+                fontSize: 'var(--text-sm)',
+                fontWeight: 'var(--font-medium)',
+                cursor: 'pointer',
+                transition: 'var(--transition-fast)',
+              }}
+            >
+              {label}
+            </button>
+          );
+        })}
       </div>
 
       {error && (
@@ -481,40 +554,48 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
         </div>
       )}
 
-      {isLoading && proposals.length === 0 ? (
+      {isLoading && filteredProposals.length === 0 ? (
         <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--space-6) 0' }}>
           <LoadingSpinner size="md" />
         </div>
       ) : null}
 
       {!isLoading && (totalProposals ?? 0) === 0 && !error ? (
-        <p style={{
-          margin: 0,
-          color: 'var(--text-muted)',
-          fontSize: 'var(--text-sm)',
-        }}>
+        <p style={{ margin: 0, color: 'var(--text-muted)', fontSize: 'var(--text-sm)' }}>
           No governance proposals found.
         </p>
       ) : null}
 
-      {proposals.length > 0 && !isMobile && (
-        <div style={{
-          overflowX: 'auto',
-          borderRadius: 'var(--radius-md)',
-          border: '1px solid var(--border-primary)',
-          marginBottom: 'var(--space-4)',
-        }}>
-          <table style={{
-            width: '100%',
-            borderCollapse: 'collapse',
-            fontSize: 'var(--text-sm)',
-          }}>
+      {!isLoading && (totalProposals ?? 0) > 0 && filteredProposals.length === 0 && !error ? (
+        <p style={{ margin: 0, color: 'var(--text-muted)', fontSize: 'var(--text-sm)' }}>
+          No proposals match this filter.
+        </p>
+      ) : null}
+
+      {filteredProposals.length > 0 && !isMobile && (
+        <div
+          style={{
+            overflowX: 'auto',
+            borderRadius: 'var(--radius-md)',
+            border: '1px solid var(--border-primary)',
+            marginBottom: 'var(--space-4)',
+          }}
+        >
+          <table
+            style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontSize: 'var(--text-sm)',
+            }}
+          >
             <thead>
-              <tr style={{
-                background: 'var(--bg-tertiary)',
-                color: 'var(--text-secondary)',
-                textAlign: 'left',
-              }}>
+              <tr
+                style={{
+                  background: 'var(--bg-tertiary)',
+                  color: 'var(--text-secondary)',
+                  textAlign: 'left',
+                }}
+              >
                 <th style={{ padding: 'var(--space-3)' }}>ID</th>
                 <th style={{ padding: 'var(--space-3)' }}>Type</th>
                 <th style={{ padding: 'var(--space-3)' }}>Argument</th>
@@ -526,43 +607,44 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
               </tr>
             </thead>
             <tbody>
-              {proposals.map((proposal) => {
+              {filteredProposals.map((proposal) => {
+                const isVoting = voteStatus?.proposalId === proposal.id;
                 const hasVoted = normalizedWalletAddress
                   ? proposal.voters.some((voter) => voter.toLowerCase() === normalizedWalletAddress)
                   : false;
-                const isVoting = voteStatus?.proposalId === proposal.id;
 
                 return (
                   <tr
                     key={proposal.id}
                     style={{
-                      borderTop: '1px solid var(--border-primary)',
+                      borderBottom: '1px solid var(--border-primary)',
                       background: 'var(--bg-secondary)',
                     }}
                   >
                     <td style={{ padding: 'var(--space-3)', fontFamily: 'var(--font-mono)' }}>{proposal.id}</td>
-                    <td style={{ padding: 'var(--space-3)', textTransform: 'capitalize' }}>{proposal.type.replace(/_/g, ' ')}</td>
-                    <td
-                      style={{
-                        padding: 'var(--space-3)',
-                        verticalAlign: 'middle',
-                      }}
-                    >
-                      {renderProposalArgument(proposal.arg)}
+                    <td style={{ padding: 'var(--space-3)', textTransform: 'capitalize' }}>
+                      {proposal.type.replace(/_/g, ' ')}
                     </td>
-                    <td style={{ padding: 'var(--space-3)', color: 'var(--color-success)', fontWeight: 'var(--font-medium)' }}>{proposal.yes}</td>
-                    <td style={{ padding: 'var(--space-3)', color: 'var(--color-warning)', fontWeight: 'var(--font-medium)' }}>{proposal.no}</td>
+                    <td style={{ padding: 'var(--space-3)' }}>{renderProposalArgument(proposal.arg)}</td>
+                    <td style={{ padding: 'var(--space-3)', color: 'var(--color-success)', fontWeight: 'var(--font-medium)' }}>
+                      {proposal.yes}
+                    </td>
+                    <td style={{ padding: 'var(--space-3)', color: 'var(--color-warning)', fontWeight: 'var(--font-medium)' }}>
+                      {proposal.no}
+                    </td>
                     <td style={{ padding: 'var(--space-3)' }}>{proposal.finalized ? 'Yes' : 'No'}</td>
                     <td style={{ padding: 'var(--space-3)' }}>
-                      <div style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 'var(--space-1)',
-                      }}>
-                        {proposal.voters.length === 0 ? (
-                          <span style={{ color: 'var(--text-muted)' }}>No votes yet</span>
-                        ) : (
-                          proposal.voters.map((voter) => (
+                      {proposal.voters.length === 0 ? (
+                        <span style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>No votes yet</span>
+                      ) : (
+                        <div
+                          style={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: 'var(--space-1)',
+                          }}
+                        >
+                          {proposal.voters.map((voter) => (
                             <span
                               key={voter}
                               style={{
@@ -574,9 +656,9 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
                             >
                               {voter}
                             </span>
-                          ))
-                        )}
-                      </div>
+                          ))}
+                        </div>
+                      )}
                     </td>
                     <td style={{ padding: 'var(--space-3)' }}>
                       {proposal.finalized ? (
@@ -586,7 +668,7 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
                       ) : hasVoted ? (
                         <span style={{ color: 'var(--text-secondary)' }}>Already voted</span>
                       ) : (
-                        <div style={{ display: 'flex', gap: 'var(--space-2)', flexWrap: 'wrap' }}>
+                        <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
                           <button
                             type="button"
                             onClick={() => handleVote(proposal.id, 'yes')}
@@ -634,119 +716,116 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
         </div>
       )}
 
-      {proposals.length > 0 && isMobile && (
-        <div style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 'var(--space-3)',
-          marginBottom: 'var(--space-4)',
-        }}>
-          {proposals.map((proposal) => {
+      {filteredProposals.length > 0 && isMobile && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--space-3)',
+            marginBottom: 'var(--space-4)',
+          }}
+        >
+          {filteredProposals.map((proposal) => {
+            const isVoting = voteStatus?.proposalId === proposal.id;
             const hasVoted = normalizedWalletAddress
               ? proposal.voters.some((voter) => voter.toLowerCase() === normalizedWalletAddress)
               : false;
-            const isVoting = voteStatus?.proposalId === proposal.id;
 
             return (
               <div
                 key={proposal.id}
                 style={{
-                  border: '1px solid var(--border-primary)',
-                  borderRadius: 'var(--radius-md)',
-                  background: 'var(--bg-secondary)',
-                  padding: 'var(--space-3)',
                   display: 'flex',
                   flexDirection: 'column',
-                  gap: 'var(--space-2)',
+                  gap: 'var(--space-3)',
+                  padding: 'var(--space-3)',
+                  borderRadius: 'var(--radius-md)',
+                  border: '1px solid var(--border-primary)',
+                  background: 'var(--bg-secondary)',
                 }}
               >
-                <div style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  flexWrap: 'wrap',
-                  gap: 'var(--space-2)',
-                }}>
-                  <span style={{ fontFamily: 'var(--font-mono)', fontWeight: 'var(--font-medium)' }}>
-                    #{proposal.id}
-                  </span>
-                  <span style={{
-                    textTransform: 'capitalize',
-                    color: 'var(--text-secondary)',
-                    fontWeight: 'var(--font-medium)',
-                  }}>
-                    {proposal.type.replace(/_/g, ' ')}
-                  </span>
-                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-start',
+                    gap: 'var(--space-2)',
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  <div>
+                    <span style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--text-sm)', fontWeight: 'var(--font-medium)' }}>
+                      #{proposal.id}
+                    </span>
+                    <span
+                      style={{
+                        display: 'block',
+                        fontSize: 'var(--text-sm)',
+                        color: 'var(--text-secondary)',
+                        textTransform: 'capitalize',
+                      }}
+                    >
+                      {proposal.type.replace(/_/g, ' ')}
+                    </span>
+                  </div>
 
-                <div>
-                  <span style={{
-                    display: 'block',
-                    fontSize: 'var(--text-xs)',
-                    color: 'var(--text-muted)',
-                    marginBottom: 'var(--space-1)',
-                  }}>
-                    Argument
-                  </span>
-                  <div style={{ fontSize: 'var(--text-sm)' }}>
-                    {renderProposalArgument(proposal.arg)}
+                  <div>
+                    <span
+                      style={{
+                        display: 'block',
+                        fontSize: 'var(--text-xs)',
+                        color: 'var(--text-muted)',
+                        marginBottom: 'var(--space-1)',
+                      }}
+                    >
+                      Argument
+                    </span>
+                    <div style={{ fontSize: 'var(--text-sm)' }}>{renderProposalArgument(proposal.arg)}</div>
                   </div>
                 </div>
 
-                <div style={{
-                  display: 'grid',
-                  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-                  gap: 'var(--space-2)',
-                }}>
-                  <div style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 'var(--space-1)',
-                    alignItems: 'flex-start',
-                  }}>
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+                    gap: 'var(--space-2)',
+                  }}
+                >
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)', alignItems: 'flex-start' }}>
                     <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Yes</span>
-                    <span style={{ color: 'var(--color-success)', fontWeight: 'var(--font-medium)' }}>
-                      {proposal.yes}
-                    </span>
+                    <span style={{ color: 'var(--color-success)', fontWeight: 'var(--font-medium)' }}>{proposal.yes}</span>
                   </div>
-                  <div style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 'var(--space-1)',
-                    alignItems: 'flex-start',
-                  }}>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)', alignItems: 'flex-start' }}>
                     <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>No</span>
-                    <span style={{ color: 'var(--color-warning)', fontWeight: 'var(--font-medium)' }}>
-                      {proposal.no}
-                    </span>
+                    <span style={{ color: 'var(--color-warning)', fontWeight: 'var(--font-medium)' }}>{proposal.no}</span>
                   </div>
-                  <div style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 'var(--space-1)',
-                    alignItems: 'flex-start',
-                  }}>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)', alignItems: 'flex-start' }}>
                     <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Finalized</span>
                     <span>{proposal.finalized ? 'Yes' : 'No'}</span>
                   </div>
                 </div>
 
                 <div>
-                  <span style={{
-                    display: 'block',
-                    fontSize: 'var(--text-xs)',
-                    color: 'var(--text-muted)',
-                    marginBottom: 'var(--space-1)',
-                  }}>
+                  <span
+                    style={{
+                      display: 'block',
+                      fontSize: 'var(--text-xs)',
+                      color: 'var(--text-muted)',
+                      marginBottom: 'var(--space-1)',
+                    }}
+                  >
                     Voters
                   </span>
                   {proposal.voters.length === 0 ? (
                     <span style={{ color: 'var(--text-muted)' }}>No votes yet</span>
                   ) : (
-                    <div style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      gap: 'var(--space-1)',
-                    }}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 'var(--space-1)',
+                      }}
+                    >
                       {proposal.voters.map((voter) => (
                         <span
                           key={voter}
@@ -763,13 +842,16 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
                     </div>
                   )}
                 </div>
+
                 <div>
-                  <span style={{
-                    display: 'block',
-                    fontSize: 'var(--text-xs)',
-                    color: 'var(--text-muted)',
-                    marginBottom: 'var(--space-1)',
-                  }}>
+                  <span
+                    style={{
+                      display: 'block',
+                      fontSize: 'var(--text-xs)',
+                      color: 'var(--text-muted)',
+                      marginBottom: 'var(--space-1)',
+                    }}
+                  >
                     Actions
                   </span>
                   {proposal.finalized ? (
@@ -825,14 +907,16 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
         </div>
       )}
 
-      {totalPages > 1 && (
-        <div style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: 'var(--space-3)',
-          flexWrap: 'wrap',
-        }}>
+      {totalPages > 1 && filteredProposals.length > 0 && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 'var(--space-3)',
+            flexWrap: 'wrap',
+          }}
+        >
           <button
             type="button"
             onClick={handlePrevious}
@@ -870,6 +954,113 @@ export function GovernanceCard({ isValidator, governance }: GovernanceCardProps)
           </button>
         </div>
       )}
+
+      <Modal isOpen={isProposalModalOpen} onClose={closeProposalModal} title="Create proposal">
+        <form
+          onSubmit={handleSubmitProposal}
+          style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}
+        >
+          <div>
+            <p style={{ margin: 0, fontSize: 'var(--text-sm)', color: 'var(--text-secondary)' }}>
+              Submit a governance proposal using your connected wallet.
+            </p>
+            {walletInfo ? (
+              <p
+                style={{
+                  margin: 0,
+                  marginTop: 'var(--space-1)',
+                  fontSize: 'var(--text-xs)',
+                  color: 'var(--text-muted)',
+                  fontFamily: 'var(--font-mono)',
+                }}
+              >
+                {walletInfo.truncatedAddress ?? walletInfo.address}
+              </p>
+            ) : (
+              <p style={{ margin: 0, marginTop: 'var(--space-1)', fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+                Connect your wallet before submitting a proposal.
+              </p>
+            )}
+          </div>
+
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+            <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Proposal Type</span>
+            <input
+              type="text"
+              value={proposalType}
+              onChange={(event) => setProposalType(event.target.value)}
+              placeholder="e.g. add_member"
+              style={{
+                padding: 'var(--space-2)',
+                borderRadius: 'var(--radius-sm)',
+                border: '1px solid var(--border-primary)',
+                background: 'var(--bg-tertiary)',
+                color: 'var(--text-primary)',
+                fontSize: 'var(--text-sm)',
+              }}
+            />
+          </label>
+
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+            <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Proposal Argument</span>
+            <textarea
+              value={proposalArgument}
+              onChange={(event) => setProposalArgument(event.target.value)}
+              placeholder="Argument value (text, number, or JSON)"
+              rows={4}
+              style={{
+                padding: 'var(--space-2)',
+                borderRadius: 'var(--radius-sm)',
+                border: '1px solid var(--border-primary)',
+                background: 'var(--bg-tertiary)',
+                color: 'var(--text-primary)',
+                fontSize: 'var(--text-sm)',
+                resize: 'vertical',
+              }}
+            />
+          </label>
+
+          {proposalError ? (
+            <span style={{ color: 'var(--color-error)', fontSize: 'var(--text-sm)' }}>{proposalError}</span>
+          ) : null}
+
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 'var(--space-2)' }}>
+            <button
+              type="button"
+              onClick={closeProposalModal}
+              disabled={isSubmittingProposal}
+              style={{
+                padding: 'var(--space-2) var(--space-3)',
+                borderRadius: 'var(--radius-md)',
+                border: '1px solid var(--border-primary)',
+                background: 'var(--bg-tertiary)',
+                color: 'var(--text-secondary)',
+                fontSize: 'var(--text-sm)',
+                cursor: isSubmittingProposal ? 'default' : 'pointer',
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmittingProposal || !walletInfo || walletInfo.locked}
+              style={{
+                padding: 'var(--space-2) var(--space-3)',
+                borderRadius: 'var(--radius-md)',
+                border: 'none',
+                background: 'var(--primary-gradient)',
+                color: 'white',
+                fontSize: 'var(--text-sm)',
+                fontWeight: 'var(--font-medium)',
+                cursor: isSubmittingProposal || !walletInfo || walletInfo.locked ? 'default' : 'pointer',
+                opacity: isSubmittingProposal || !walletInfo || walletInfo.locked ? 0.7 : 1,
+              }}
+            >
+              {isSubmittingProposal ? 'Submitting…' : 'Submit Proposal'}
+            </button>
+          </div>
+        </form>
+      </Modal>
     </Card>
   );
 }

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -122,3 +122,25 @@ export function PencilIcon({ size = 16, className = '', style = {} }: IconProps)
     </svg>
   );
 }
+
+export function WalletIcon({ size = 16, className = '', style = {} }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      style={style}
+    >
+      <rect x="2" y="6" width="20" height="14" rx="3" ry="3" />
+      <path d="M18 12h-4a2 2 0 0 0 0 4h4" />
+      <circle cx="16" cy="14" r="1" fill="currentColor" stroke="none" />
+      <path d="M2 10h14a2 2 0 0 0 2-2V6" />
+    </svg>
+  );
+}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,113 @@
+import { MouseEvent, ReactNode, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { XIcon } from './Icons';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+}
+
+export function Modal({ isOpen, onClose, title, children }: ModalProps) {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    const { style } = document.body;
+    const previousOverflow = style.overflow;
+    style.overflow = 'hidden';
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      style.overflow = previousOverflow;
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  return createPortal(
+    <div
+      role="presentation"
+      onClick={handleBackdropClick}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(10, 10, 22, 0.65)',
+        backdropFilter: 'blur(8px)',
+        zIndex: 1000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 'var(--space-4)',
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title ?? 'Modal dialog'}
+        style={{
+          background: 'var(--bg-primary)',
+          borderRadius: 'var(--radius-lg)',
+          border: '1px solid var(--border-primary)',
+          boxShadow: '0 20px 40px rgba(2, 12, 27, 0.25)',
+          width: 'min(520px, 100%)',
+          maxHeight: '90vh',
+          overflow: 'auto',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 'var(--space-2)',
+            padding: 'var(--space-3) var(--space-4)',
+            borderBottom: '1px solid var(--border-primary)',
+          }}
+        >
+          <h2 style={{ margin: 0, fontSize: 'var(--text-lg)', color: 'var(--text-secondary)' }}>
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close modal"
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: 'var(--text-muted)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: 'var(--space-1)',
+            }}
+          >
+            <XIcon size={18} />
+          </button>
+        </div>
+        <div style={{ padding: 'var(--space-4)', display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+          {children}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,0 +1,50 @@
+import { useCallback, useState } from 'react';
+import XianWalletUtils from '../services/xianWalletUtils';
+
+export interface ConnectedWalletInfo {
+  address: string;
+  truncatedAddress?: string;
+  locked?: boolean;
+  chainId?: string;
+}
+
+interface UseWalletResult {
+  walletInfo: ConnectedWalletInfo | null;
+  isConnecting: boolean;
+  error: string | null;
+  connect: () => Promise<void>;
+  clearError: () => void;
+}
+
+export function useWallet(): UseWalletResult {
+  const [walletInfo, setWalletInfo] = useState<ConnectedWalletInfo | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const connect = useCallback(async () => {
+    setError(null);
+    setIsConnecting(true);
+    try {
+      const info = await XianWalletUtils.requestWalletInfo();
+      setWalletInfo(info);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to connect wallet';
+      setWalletInfo(null);
+      setError(message);
+    } finally {
+      setIsConnecting(false);
+    }
+  }, []);
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return {
+    walletInfo,
+    isConnecting,
+    error,
+    connect,
+    clearError,
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable `useWallet` hook and surface wallet state through the dashboard
- replace the header refresh control with wallet connect status and error messaging
- redesign the governance card with tabbed filters and a modal proposal form

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dac368ef188320b2da5bda697cbc13