### PR TITLE
Fix GovernanceCard hook order issue

### DIFF
--- a/src/components/GovernanceCard.tsx
+++ b/src/components/GovernanceCard.tsx
@@ -99,6 +99,24 @@ export function GovernanceCard({
   walletError,
   clearWalletError,
 }: GovernanceCardProps) {
+  if (!isValidator) {
+    return (
+      <Card title="Governance Votes">
+        <p
+          style={{
+            margin: 0,
+            color: 'var(--text-muted)',
+            fontSize: 'var(--text-sm)',
+            lineHeight: 1.6,
+          }}
+        >
+          This node is not currently participating as a validator. Governance data is
+          only available for validator nodes.
+        </p>
+      </Card>
+    );
+  }
+
   const [isMobile, setIsMobile] = useState(false);
   const [proposalType, setProposalType] = useState('');
   const [proposalArgument, setProposalArgument] = useState('');
@@ -253,22 +271,6 @@ export function GovernanceCard({
     },
     [clearWalletError, refresh, walletInfo],
   );
-
-  if (!isValidator) {
-    return (
-      <Card title="Governance Votes">
-        <p style={{
-          margin: 0,
-          color: 'var(--text-muted)',
-          fontSize: 'var(--text-sm)',
-          lineHeight: 1.6,
-        }}>
-          This node is not currently participating as a validator. Governance data is
-          only available for validator nodes.
-        </p>
-      </Card>
-    );
-  }
 
   const handlePrevious = () => {
     if (page > 1) {


### PR DESCRIPTION
## Summary
- return early for non-validator nodes before running any hooks in GovernanceCard to keep hook ordering stable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dac9fc8d00832083794aba8a139804