### PR TITLE
Convert dashboard layout to tabbed interface

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -11,8 +11,11 @@ import { useGovernance } from '../hooks/useGovernance';
 import { GovernanceCard } from './GovernanceCard';
 import { useWallet } from '../hooks/useWallet';
 
+type DashboardTab = 'overview' | 'health' | 'network' | 'governance';
+
 export function Dashboard() {
   const [nodeUrl, setNodeUrl] = useState('https://node.xian.org');
+  const [activeTab, setActiveTab] = useState<DashboardTab>('overview');
   const { data } = useCometBFT({
     nodeUrl,
     refreshInterval: 5000,
@@ -37,6 +40,29 @@ export function Dashboard() {
     setNodeUrl(url);
   };
 
+  const tabConfig: { id: DashboardTab; label: string; description: string }[] = [
+    {
+      id: 'overview',
+      label: 'Node overview',
+      description: 'Current validator identity, peers and uptime',
+    },
+    {
+      id: 'health',
+      label: 'Health & consensus',
+      description: 'Live heartbeat, block production and participation metrics',
+    },
+    {
+      id: 'network',
+      label: 'Network activity',
+      description: 'Peer connectivity, throughput and mempool insights',
+    },
+    {
+      id: 'governance',
+      label: 'Version & governance',
+      description: 'Release alignment and validator decision tracking',
+    },
+  ];
+
   return (
     <div className="dashboard-container">
       <Header
@@ -49,78 +75,131 @@ export function Dashboard() {
       />
 
       <main className="dashboard-content">
-        <section className="dashboard-section">
-          <div className="dashboard-section__header">
-            <h2 className="dashboard-section__title">Node overview</h2>
-            <p className="dashboard-section__subtitle">
-              Current validator identity, peers and uptime
-            </p>
-          </div>
-          <div className="dashboard-grid dashboard-grid--single">
-            <div className="dashboard-item">
-              <NodeStatusCard data={data} />
-            </div>
-          </div>
-        </section>
+        <div className="dashboard-tabs" role="tablist" aria-label="Dashboard sections">
+          {tabConfig.map((tab) => {
+            const isActive = activeTab === tab.id;
+            const buttonId = `dashboard-tab-${tab.id}`;
+            const panelId = `dashboard-panel-${tab.id}`;
 
-        <section className="dashboard-section">
-          <div className="dashboard-section__header">
-            <h2 className="dashboard-section__title">Health &amp; consensus</h2>
-            <p className="dashboard-section__subtitle">
-              Live heartbeat, block production and participation metrics
-            </p>
-          </div>
-          <div className="dashboard-grid">
-            <div className="dashboard-item">
-              <HealthAlertsCard data={data} />
-            </div>
-            <div className="dashboard-item">
-              <ConsensusStateCard data={data} />
-            </div>
-          </div>
-        </section>
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                id={buttonId}
+                aria-controls={panelId}
+                tabIndex={isActive ? 0 : -1}
+                className={`dashboard-tab${isActive ? ' dashboard-tab--active' : ''}`}
+                onClick={() => setActiveTab(tab.id)}
+              >
+                <span className="dashboard-tab__label">{tab.label}</span>
+                <span className="dashboard-tab__description">{tab.description}</span>
+              </button>
+            );
+          })}
+        </div>
 
-        <section className="dashboard-section">
-          <div className="dashboard-section__header">
-            <h2 className="dashboard-section__title">Network activity</h2>
-            <p className="dashboard-section__subtitle">
-              Peer connectivity, throughput and mempool insights
-            </p>
-          </div>
-          <div className="dashboard-grid">
-            <div className="dashboard-item">
-              <NetworkInfoCard data={data} />
+        {activeTab === 'overview' && (
+          <section
+            className="dashboard-section"
+            role="tabpanel"
+            id="dashboard-panel-overview"
+            aria-labelledby="dashboard-tab-overview"
+          >
+            <div className="dashboard-section__header">
+              <h2 className="dashboard-section__title">Node overview</h2>
+              <p className="dashboard-section__subtitle">
+                Current validator identity, peers and uptime
+              </p>
             </div>
-            <div className="dashboard-item">
-              <MempoolCard data={data} />
+            <div className="dashboard-grid dashboard-grid--single">
+              <div className="dashboard-item">
+                <NodeStatusCard data={data} />
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
+        )}
 
-        <section className="dashboard-section">
-          <div className="dashboard-section__header">
-            <h2 className="dashboard-section__title">Version &amp; governance</h2>
-            <p className="dashboard-section__subtitle">
-              Release alignment and validator decision tracking
-            </p>
-          </div>
-          <div className="dashboard-grid">
-            <div className="dashboard-item">
-              <VersionInfoCard data={data} />
+        {activeTab === 'health' && (
+          <section
+            className="dashboard-section"
+            role="tabpanel"
+            id="dashboard-panel-health"
+            aria-labelledby="dashboard-tab-health"
+          >
+            <div className="dashboard-section__header">
+              <h2 className="dashboard-section__title">Health &amp; consensus</h2>
+              <p className="dashboard-section__subtitle">
+                Live heartbeat, block production and participation metrics
+              </p>
             </div>
-            <div className="dashboard-item dashboard-item--wide">
-              <GovernanceCard
-                isValidator={isValidator}
-                governance={governance}
-                walletInfo={wallet.walletInfo}
-                isConnectingWallet={wallet.isConnecting}
-                onConnectWallet={wallet.connect}
-                walletError={wallet.error}
-                clearWalletError={wallet.clearError}
-              />
+            <div className="dashboard-grid">
+              <div className="dashboard-item">
+                <HealthAlertsCard data={data} />
+              </div>
+              <div className="dashboard-item">
+                <ConsensusStateCard data={data} />
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
+        )}
+
+        {activeTab === 'network' && (
+          <section
+            className="dashboard-section"
+            role="tabpanel"
+            id="dashboard-panel-network"
+            aria-labelledby="dashboard-tab-network"
+          >
+            <div className="dashboard-section__header">
+              <h2 className="dashboard-section__title">Network activity</h2>
+              <p className="dashboard-section__subtitle">
+                Peer connectivity, throughput and mempool insights
+              </p>
+            </div>
+            <div className="dashboard-grid">
+              <div className="dashboard-item">
+                <NetworkInfoCard data={data} />
+              </div>
+              <div className="dashboard-item">
+                <MempoolCard data={data} />
+              </div>
+            </div>
+          </section>
+        )}
+
+        {activeTab === 'governance' && (
+          <section
+            className="dashboard-section"
+            role="tabpanel"
+            id="dashboard-panel-governance"
+            aria-labelledby="dashboard-tab-governance"
+          >
+            <div className="dashboard-section__header">
+              <h2 className="dashboard-section__title">Version &amp; governance</h2>
+              <p className="dashboard-section__subtitle">
+                Release alignment and validator decision tracking
+              </p>
+            </div>
+            <div className="dashboard-grid">
+              <div className="dashboard-item">
+                <VersionInfoCard data={data} />
+              </div>
+              <div className="dashboard-item dashboard-item--wide">
+                <GovernanceCard
+                  isValidator={isValidator}
+                  governance={governance}
+                  walletInfo={wallet.walletInfo}
+                  isConnectingWallet={wallet.isConnecting}
+                  onConnectWallet={wallet.connect}
+                  walletError={wallet.error}
+                  clearWalletError={wallet.clearError}
+                />
+              </div>
+            </div>
+          </section>
+        )}
       </main>
 
       <footer className="dashboard-footer">

--- a/src/components/GovernanceCard.tsx
+++ b/src/components/GovernanceCard.tsx
@@ -127,7 +127,6 @@ export function GovernanceCard({
   const [voteMessage, setVoteMessage] = useState<string | null>(null);
   const [voteError, setVoteError] = useState<string | null>(null);
   const [isProposalModalOpen, setIsProposalModalOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<'all' | 'active' | 'finalized'>('all');
 
   const {
     totalProposals,
@@ -284,18 +283,6 @@ export function GovernanceCard({
     }
   };
 
-  const filteredProposals = useMemo(() => {
-    if (activeTab === 'active') {
-      return proposals.filter((proposal) => !proposal.finalized);
-    }
-
-    if (activeTab === 'finalized') {
-      return proposals.filter((proposal) => proposal.finalized);
-    }
-
-    return proposals;
-  }, [activeTab, proposals]);
-
   const activeCount = useMemo(
     () => proposals.filter((proposal) => !proposal.finalized).length,
     [proposals],
@@ -306,20 +293,11 @@ export function GovernanceCard({
     [proposals],
   );
 
-  const tabOptions = useMemo(
-    () => [
-      { key: 'all' as const, label: `All (${proposals.length})` },
-      { key: 'active' as const, label: `Active (${activeCount})` },
-      { key: 'finalized' as const, label: `Finalized (${finalizedCount})` },
-    ],
-    [activeCount, finalizedCount, proposals.length],
-  );
-
-  const showingFrom = filteredProposals.length > 0
-    ? filteredProposals[0].id
+  const showingFrom = proposals.length > 0
+    ? proposals[0].id
     : 0;
-  const showingTo = filteredProposals.length > 0
-    ? filteredProposals[filteredProposals.length - 1].id
+  const showingTo = proposals.length > 0
+    ? proposals[proposals.length - 1].id
     : 0;
 
   return (
@@ -498,7 +476,7 @@ export function GovernanceCard({
           <p style={{ margin: 0, fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>
             Total proposals: {totalProposals ?? '—'}
           </p>
-          {totalProposals && totalProposals > 0 && filteredProposals.length > 0 ? (
+          {totalProposals && totalProposals > 0 && proposals.length > 0 ? (
             <p
               style={{
                 margin: 0,
@@ -517,32 +495,6 @@ export function GovernanceCard({
         </div>
       </div>
 
-      <div style={{ display: 'flex', gap: 'var(--space-2)', flexWrap: 'wrap', marginBottom: 'var(--space-3)' }}>
-        {tabOptions.map(({ key, label }) => {
-          const isActive = activeTab === key;
-          return (
-            <button
-              key={key}
-              type="button"
-              onClick={() => setActiveTab(key)}
-              style={{
-                padding: 'var(--space-2) var(--space-3)',
-                borderRadius: 'var(--radius-md)',
-                border: isActive ? 'none' : '1px solid var(--border-primary)',
-                background: isActive ? 'var(--primary-gradient)' : 'var(--bg-secondary)',
-                color: isActive ? 'white' : 'var(--text-secondary)',
-                fontSize: 'var(--text-sm)',
-                fontWeight: 'var(--font-medium)',
-                cursor: 'pointer',
-                transition: 'var(--transition-fast)',
-              }}
-            >
-              {label}
-            </button>
-          );
-        })}
-      </div>
-
       {error && (
         <div
           style={{
@@ -558,7 +510,7 @@ export function GovernanceCard({
         </div>
       )}
 
-      {isLoading && filteredProposals.length === 0 ? (
+      {isLoading && proposals.length === 0 ? (
         <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--space-6) 0' }}>
           <LoadingSpinner size="md" />
         </div>
@@ -570,13 +522,13 @@ export function GovernanceCard({
         </p>
       ) : null}
 
-      {!isLoading && (totalProposals ?? 0) > 0 && filteredProposals.length === 0 && !error ? (
+      {!isLoading && (totalProposals ?? 0) > 0 && proposals.length === 0 && !error ? (
         <p style={{ margin: 0, color: 'var(--text-muted)', fontSize: 'var(--text-sm)' }}>
-          No proposals match this filter.
+          No proposals available on this page.
         </p>
       ) : null}
 
-      {filteredProposals.length > 0 && !isMobile && (
+      {proposals.length > 0 && !isMobile && (
         <div
           style={{
             overflowX: 'auto',
@@ -611,7 +563,7 @@ export function GovernanceCard({
               </tr>
             </thead>
             <tbody>
-              {filteredProposals.map((proposal) => {
+              {proposals.map((proposal) => {
                 const isVoting = voteStatus?.proposalId === proposal.id;
                 const hasVoted = normalizedWalletAddress
                   ? proposal.voters.some((voter) => voter.toLowerCase() === normalizedWalletAddress)
@@ -720,7 +672,7 @@ export function GovernanceCard({
         </div>
       )}
 
-      {filteredProposals.length > 0 && isMobile && (
+      {proposals.length > 0 && isMobile && (
         <div
           style={{
             display: 'flex',
@@ -729,7 +681,7 @@ export function GovernanceCard({
             marginBottom: 'var(--space-4)',
           }}
         >
-          {filteredProposals.map((proposal) => {
+          {proposals.map((proposal) => {
             const isVoting = voteStatus?.proposalId === proposal.id;
             const hasVoted = normalizedWalletAddress
               ? proposal.voters.some((voter) => voter.toLowerCase() === normalizedWalletAddress)
@@ -911,7 +863,7 @@ export function GovernanceCard({
         </div>
       )}
 
-      {totalPages > 1 && filteredProposals.length > 0 && (
+      {totalPages > 1 && proposals.length > 0 && (
         <div
           style={{
             display: 'flex',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -254,6 +254,56 @@ body {
   grid-template-columns: minmax(0, 1fr);
 }
 
+.dashboard-tabs {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.dashboard-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+  transition: all var(--transition-normal);
+}
+
+.dashboard-tab:hover,
+.dashboard-tab:focus-visible {
+  border-color: var(--border-accent);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-glow);
+}
+
+.dashboard-tab--active {
+  background: var(--bg-card);
+  border-color: var(--border-accent);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-glow);
+}
+
+.dashboard-tab__label {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+}
+
+.dashboard-tab__description {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.dashboard-tab--active .dashboard-tab__description {
+  color: var(--text-secondary);
+}
+
 .dashboard-item {
   min-width: 0;
 }


### PR DESCRIPTION
## Summary
- replace the stacked dashboard sections with top-level tabs for each feature area and wire them up to existing cards
- remove the inactive/active/finalized filters from the governance card to avoid confusing views when proposals are paged
- add styling for the new tab navigation to match the dashboard visuals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dacadd769c83209759186c5c06a08a