### PR TITLE
Support HTTP RPC node input with proxy handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A modern, real-time dashboard for monitoring CometBFT 0.38.12 node health and st
 - **Mempool Activity**: Pending transactions, queue depth, and recent transaction previews
 
 ### User Experience
-- **Configurable Node URL**: Easy switching between different CometBFT nodes
+- **Configurable Node endpoint**: Enter an IP or hostname, the dashboard handles the RPC port and HTTP proxying automatically
 - **Real-time Updates**: Auto-refresh every 5 seconds with manual refresh option
 - **Responsive Design**: Works seamlessly on desktop, tablet, and mobile devices
 - **Modern UI**: Dark theme with gradient accents and smooth animations
@@ -105,8 +105,10 @@ CMD ["npm", "run", "preview"]
 ## 🔧 Configuration
 
 ### Node URL Configuration
-- Click on the node URL in the header to edit
-- Default: `https://node.xian.org`
+- Click on the node address in the header to edit
+- Default: `89.163.130.217`
+- Enter just the IP/hostname; the dashboard appends the RPC port `26657` for you
+- HTTP-only nodes are proxied through `https://cors.isomorphic-git.org` to avoid browser mixed-content errors
 - Supports any CometBFT node with REST API enabled
 
 ### Environment Variables

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,13 @@
-import { useState, FormEvent } from 'react';
+import { useEffect, useState, FormEvent } from 'react';
 import { LoadingSpinner } from './LoadingSpinner';
-import { cometbftService } from '../services/cometbft';
 import { CometBFTLogo, PencilIcon, WalletIcon, XIcon } from './Icons';
 import { ConnectedWalletInfo } from '../hooks/useWallet';
 
 interface HeaderProps {
-  onNodeUrlChange: (url: string) => void;
+  nodeAddress: string;
+  nodeRpcUrl: string;
+  isUsingProxy: boolean;
+  onNodeAddressChange: (value: string) => void;
   walletInfo: ConnectedWalletInfo | null;
   isConnectingWallet: boolean;
   onConnectWallet: () => void;
@@ -14,15 +16,24 @@ interface HeaderProps {
 }
 
 export function Header({
-  onNodeUrlChange,
+  nodeAddress,
+  nodeRpcUrl,
+  isUsingProxy,
+  onNodeAddressChange,
   walletInfo,
   isConnectingWallet,
   onConnectWallet,
   walletError,
   onClearWalletError,
 }: HeaderProps) {
-  const [nodeUrl, setNodeUrl] = useState(cometbftService.getBaseUrl());
+  const [nodeUrl, setNodeUrl] = useState(nodeAddress);
   const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setNodeUrl(nodeAddress);
+    }
+  }, [nodeAddress, isEditing]);
 
   const walletDisplayAddress = walletInfo?.truncatedAddress
     ?? (walletInfo?.address
@@ -31,12 +42,12 @@ export function Header({
 
   const handleUrlSubmit = (e: FormEvent) => {
     e.preventDefault();
-    onNodeUrlChange(nodeUrl);
+    onNodeAddressChange(nodeUrl.trim());
     setIsEditing(false);
   };
 
   const handleUrlReset = () => {
-    setNodeUrl(cometbftService.getBaseUrl());
+    setNodeUrl(nodeAddress);
     setIsEditing(false);
   };
 
@@ -97,12 +108,12 @@ export function Header({
         {/* Node URL Configuration */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
           {isEditing ? (
-            <form onSubmit={handleUrlSubmit} style={{ display: 'flex', gap: 'var(--space-2)' }}>
+            <form onSubmit={handleUrlSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
               <input
-                type="url"
+                type="text"
                 value={nodeUrl}
                 onChange={(e) => setNodeUrl(e.target.value)}
-                placeholder="https://node.example.com"
+                placeholder="89.163.130.217"
                 style={{
                   padding: 'var(--space-2) var(--space-3)',
                   background: 'var(--bg-tertiary)',
@@ -115,38 +126,47 @@ export function Header({
                 }}
                 autoFocus
               />
-              <button
-                type="submit"
-                style={{
-                  padding: 'var(--space-2) var(--space-3)',
-                  background: 'var(--primary-gradient)',
-                  border: 'none',
-                  borderRadius: 'var(--radius-md)',
-                  color: 'white',
-                  fontSize: 'var(--text-sm)',
-                  fontWeight: 'var(--font-medium)',
-                  cursor: 'pointer',
-                  transition: 'var(--transition-fast)'
-                }}
-              >
-                Save
-              </button>
-              <button
-                type="button"
-                onClick={handleUrlReset}
-                style={{
-                  padding: 'var(--space-2) var(--space-3)',
-                  background: 'transparent',
-                  border: '1px solid var(--border-primary)',
-                  borderRadius: 'var(--radius-md)',
-                  color: 'var(--text-secondary)',
-                  fontSize: 'var(--text-sm)',
-                  cursor: 'pointer',
-                  transition: 'var(--transition-fast)'
-                }}
-              >
-                Cancel
-              </button>
+              <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
+                <button
+                  type="submit"
+                  style={{
+                    padding: 'var(--space-2) var(--space-3)',
+                    background: 'var(--primary-gradient)',
+                    border: 'none',
+                    borderRadius: 'var(--radius-md)',
+                    color: 'white',
+                    fontSize: 'var(--text-sm)',
+                    fontWeight: 'var(--font-medium)',
+                    cursor: 'pointer',
+                    transition: 'var(--transition-fast)'
+                  }}
+                >
+                  Save
+                </button>
+                <button
+                  type="button"
+                  onClick={handleUrlReset}
+                  style={{
+                    padding: 'var(--space-2) var(--space-3)',
+                    background: 'transparent',
+                    border: '1px solid var(--border-primary)',
+                    borderRadius: 'var(--radius-md)',
+                    color: 'var(--text-secondary)',
+                    fontSize: 'var(--text-sm)',
+                    cursor: 'pointer',
+                    transition: 'var(--transition-fast)'
+                  }}
+                >
+                  Cancel
+                </button>
+              </div>
+              <p style={{
+                margin: 0,
+                fontSize: 'var(--text-xs)',
+                color: 'var(--text-muted)'
+              }}>
+                RPC port 26657 is appended automatically{isUsingProxy ? ' and HTTP endpoints are proxied to keep the dashboard secure.' : '.'}
+              </p>
             </form>
           ) : (
             <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
@@ -176,11 +196,11 @@ export function Header({
                   alignItems: 'center',
                   gap: 'var(--space-2)'
                 }}
-                title={nodeUrl}
-                aria-label={`Edit node URL ${nodeUrl}`}
+                title={nodeRpcUrl}
+                aria-label={`Edit node address ${nodeAddress}`}
               >
                 <PencilIcon size={14} style={{ flexShrink: 0 }} />
-                {nodeUrl}
+                {nodeAddress || 'Configure node'}
               </button>
             </div>
           )}

--- a/src/services/cometbft.ts
+++ b/src/services/cometbft.ts
@@ -11,12 +11,13 @@ import {
   GovernanceProposal,
   GovernanceArgument,
 } from '../types/cometbft';
+import { buildNodeConnection, DEFAULT_NODE_ADDRESS } from '../utils/nodeConnection';
 
 export class CometBFTService {
   private baseUrl: string;
   private timeout: number;
 
-  constructor(baseUrl: string = 'https://node.xian.org', timeout: number = 10000) {
+  constructor(baseUrl: string = buildNodeConnection(DEFAULT_NODE_ADDRESS).baseUrl, timeout: number = 10000) {
     this.baseUrl = baseUrl.replace(/\/$/, ''); // Remove trailing slash
     this.timeout = timeout;
   }

--- a/src/utils/nodeConnection.ts
+++ b/src/utils/nodeConnection.ts
@@ -1,0 +1,139 @@
+const DEFAULT_NODE_ADDRESS = '89.163.130.217';
+const DEFAULT_RPC_PORT = '26657';
+const HTTP_PROXY_PREFIX = 'https://cors.isomorphic-git.org/';
+
+type SupportedProtocol = 'http:' | 'https:';
+
+export interface NodeConnection {
+  /**
+   * Base URL used internally by the dashboard for all RPC requests. This may include
+   * a proxy prefix when the node only exposes HTTP.
+   */
+  baseUrl: string;
+  /**
+   * Host (and optional port) shown to the user. This preserves any user supplied
+   * port while hiding implementation details like the proxy prefix.
+   */
+  inputValue: string;
+  /**
+   * Direct RPC endpoint (protocol + host + port) used before any proxy is applied.
+   */
+  rpcUrl: string;
+  /**
+   * True when requests are routed through the proxy helper in order to access HTTP endpoints
+   * from the browser without mixed-content issues.
+   */
+  usesProxy: boolean;
+  /**
+   * Protocol chosen for the RPC connection. Defaults to HTTP when the user input does not
+   * specify one.
+   */
+  protocol: SupportedProtocol;
+  /**
+   * Hostname or IP address extracted from the user input.
+   */
+  hostname: string;
+  /**
+   * Port appended to the RPC endpoint. Defaults to 26657 unless the user explicitly
+   * provides a different port.
+   */
+  port: string;
+}
+
+const PROTOCOL_PATTERN = /^[a-zA-Z][a-zA-Z+.-]*:\/\//;
+
+function ensureLeadingProtocol(value: string): string {
+  if (!value || !value.trim()) {
+    return `http://${DEFAULT_NODE_ADDRESS}`;
+  }
+
+  if (PROTOCOL_PATTERN.test(value)) {
+    return value;
+  }
+
+  return `http://${value}`;
+}
+
+function stripHostnameBrackets(hostname: string): string {
+  if (!hostname) {
+    return hostname;
+  }
+
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    return hostname.slice(1, -1);
+  }
+
+  return hostname;
+}
+
+function normaliseHostname(hostname: string): string {
+  if (!hostname) {
+    return DEFAULT_NODE_ADDRESS;
+  }
+
+  // IPv6 hostnames need to retain brackets when a port is appended. The WHATWG URL API
+  // already includes them, so we only need to add brackets if they are missing.
+  if (hostname.includes(':') && !hostname.startsWith('[') && !hostname.endsWith(']')) {
+    return `[${hostname}]`;
+  }
+
+  return hostname;
+}
+
+function determinePort(providedPort: string | number | undefined | null): string {
+  if (typeof providedPort === 'string' && providedPort.trim().length > 0) {
+    return providedPort;
+  }
+
+  if (typeof providedPort === 'number' && Number.isFinite(providedPort)) {
+    return String(providedPort);
+  }
+
+  return DEFAULT_RPC_PORT;
+}
+
+export function buildNodeConnection(rawInput: string): NodeConnection {
+  const safeInput = rawInput?.trim() ?? '';
+  const withProtocol = ensureLeadingProtocol(safeInput || DEFAULT_NODE_ADDRESS);
+
+  let parsed: URL;
+  try {
+    parsed = new URL(withProtocol);
+  } catch (error) {
+    parsed = new URL(`http://${DEFAULT_NODE_ADDRESS}`);
+  }
+
+  const protocol = (parsed.protocol === 'https:' ? 'https:' : 'http:') as SupportedProtocol;
+  const hostname = parsed.hostname || DEFAULT_NODE_ADDRESS;
+  const normalisedHost = normaliseHostname(hostname);
+  const port = determinePort(parsed.port);
+
+  const hostWithPort = port ? `${normalisedHost}:${port}` : normalisedHost;
+  const rpcUrl = `${protocol}//${hostWithPort}`;
+  const usesProxy = protocol === 'http:';
+  const baseUrl = usesProxy ? `${HTTP_PROXY_PREFIX}${rpcUrl}` : rpcUrl;
+
+  const cleanedInput = (() => {
+    const rawHostname = stripHostnameBrackets(hostname) || DEFAULT_NODE_ADDRESS;
+    const hasCustomPort = Boolean(parsed.port && parsed.port !== DEFAULT_RPC_PORT);
+
+    if (hasCustomPort) {
+      const hostForDisplay = rawHostname.includes(':') ? `[${rawHostname}]` : rawHostname;
+      return `${hostForDisplay}:${parsed.port}`;
+    }
+
+    return rawHostname;
+  })();
+
+  return {
+    baseUrl,
+    inputValue: cleanedInput || stripHostnameBrackets(hostname),
+    rpcUrl,
+    usesProxy,
+    protocol,
+    hostname: stripHostnameBrackets(hostname),
+    port,
+  };
+}
+
+export { DEFAULT_NODE_ADDRESS, DEFAULT_RPC_PORT, HTTP_PROXY_PREFIX };


### PR DESCRIPTION
## Summary
- add a node connection helper that normalizes user input, appends the RPC port, and proxies HTTP endpoints
- update the dashboard header to focus on IP input while surfacing the proxied RPC target
- default the CometBFT service to the new HTTP test node and document the behavior in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db9846eab4832095156338aef2df2c