### PR TITLE
Detect CometBFT consensus catch-up stalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A modern, real-time dashboard for monitoring CometBFT 0.38.12 node health and st
 - **Version Information**: CometBFT version, ABCI app version, and build details
 - **Network Information**: Network ID, peer count, validator status, and connectivity
 - **Consensus State**: Height, round, step progression, and prevote/precommit participation
+- **Consensus Stall Detection**: Flags catch-up loops reported by `/dump_consensus_state` so operators can spot replay issues early
 - **Governance Proposals**: Paginated masternode proposals with live yes/no tallies, voter lists, and manual refresh support
 - **Health & Alerts**: Active issue detection, system status, and error monitoring
 - **Mempool Activity**: Pending transactions, queue depth, and recent transaction previews

--- a/src/services/cometbft.ts
+++ b/src/services/cometbft.ts
@@ -371,6 +371,17 @@ export class CometBFTService {
     consensusHealth.step =
       stepValue !== undefined && stepValue !== null ? String(stepValue) : null;
 
+    const normalizedStep =
+      typeof stepValue === 'string' ? stepValue.toLowerCase() : null;
+    const isCatchupStep = normalizedStep?.includes('catchup') ?? false;
+
+    if (isCatchupStep) {
+      const catchupMessage = status?.result.sync_info.catching_up
+        ? 'Node is stuck replaying blocks due to consensus catch-up issues'
+        : 'Consensus step indicates catch-up mode despite sync being reported complete';
+      consensusHealth.issues.push(catchupMessage);
+    }
+
     const stepNumber = (() => {
       if (typeof stepValue === 'number') {
         return Number.isFinite(stepValue) ? stepValue : null;


### PR DESCRIPTION
## Summary
- flag CometBFT consensus catch-up steps as health issues when nodes remain in replay mode
- document the new catch-up stall detection in the dashboard feature list

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcdb6df5dc8320b65cf4729c2b0571