### PR TITLE
Normalize consensus catch-up detection across step formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A modern, real-time dashboard for monitoring CometBFT 0.38.12 node health and st
 - **Version Information**: CometBFT version, ABCI app version, and build details
 - **Network Information**: Network ID, peer count, validator status, and connectivity
 - **Consensus State**: Height, round, step progression, and prevote/precommit participation
+- **Consensus Stall Detection**: Flags catch-up loops reported by `/dump_consensus_state` so operators can spot replay issues early
 - **Governance Proposals**: Paginated masternode proposals with live yes/no tallies, voter lists, and manual refresh support
 - **Health & Alerts**: Active issue detection, system status, and error monitoring
 - **Mempool Activity**: Pending transactions, queue depth, and recent transaction previews

--- a/src/services/cometbft.ts
+++ b/src/services/cometbft.ts
@@ -13,6 +13,22 @@ import {
 } from '../types/cometbft';
 import { buildNodeConnection, DEFAULT_NODE_ADDRESS } from '../utils/nodeConnection';
 
+const CONSENSUS_STEP_LABELS: Record<number, string> = {
+  0: 'RoundStepNewHeight',
+  1: 'RoundStepNewRound',
+  2: 'RoundStepPropose',
+  3: 'RoundStepPrevote',
+  4: 'RoundStepPrecommit',
+  5: 'RoundStepCommit',
+  6: 'RoundStepCatchupCommit',
+};
+
+const CONSENSUS_STEP_NAME_LOOKUP: Record<string, number> = Object.entries(CONSENSUS_STEP_LABELS)
+  .reduce((lookup, [numericStep, label]) => {
+    lookup[label.toLowerCase()] = Number(numericStep);
+    return lookup;
+  }, {} as Record<string, number>);
+
 export class CometBFTService {
   private baseUrl: string;
   private timeout: number;
@@ -338,6 +354,45 @@ export class CometBFTService {
     return this.parseVoteRatioFromVotes(votes);
   }
 
+  private interpretConsensusStep(step: number | string | null | undefined): {
+    display: string | null;
+    number: number | null;
+    normalized: string | null;
+  } {
+    if (step === null || step === undefined) {
+      return { display: null, number: null, normalized: null };
+    }
+
+    if (typeof step === 'number') {
+      if (!Number.isFinite(step)) {
+        return { display: String(step), number: null, normalized: null };
+      }
+
+      const label = CONSENSUS_STEP_LABELS[step] ?? `Step ${step}`;
+      return { display: label, number: step, normalized: label.toLowerCase() };
+    }
+
+    const rawStep = String(step).trim();
+    if (rawStep.length === 0) {
+      return { display: '', number: null, normalized: '' };
+    }
+
+    const parsedNumber = Number(rawStep);
+    if (!Number.isNaN(parsedNumber) && Number.isFinite(parsedNumber)) {
+      const label = CONSENSUS_STEP_LABELS[parsedNumber] ?? rawStep;
+      return { display: label, number: parsedNumber, normalized: label.toLowerCase() };
+    }
+
+    const normalized = rawStep.toLowerCase();
+    const mappedNumber = CONSENSUS_STEP_NAME_LOOKUP[normalized];
+    if (mappedNumber !== undefined) {
+      const label = CONSENSUS_STEP_LABELS[mappedNumber];
+      return { display: label, number: mappedNumber, normalized };
+    }
+
+    return { display: rawStep, number: null, normalized };
+  }
+
   private evaluateConsensusHealth(
     status: StatusResponse | null,
     consensusState: ConsensusStateResponse | null,
@@ -367,22 +422,19 @@ export class CometBFTService {
         : parseInt(round_state.round as string, 10);
     consensusHealth.round = Number.isFinite(roundValue) ? roundValue : null;
 
-    const stepValue = round_state.step;
-    consensusHealth.step =
-      stepValue !== undefined && stepValue !== null ? String(stepValue) : null;
+    const stepInfo = this.interpretConsensusStep(round_state.step);
+    consensusHealth.step = stepInfo.display;
 
-    const stepNumber = (() => {
-      if (typeof stepValue === 'number') {
-        return Number.isFinite(stepValue) ? stepValue : null;
-      }
+    const isCatchupStep = stepInfo.normalized?.includes('catchup') ?? false;
 
-      if (typeof stepValue === 'string') {
-        const parsed = parseInt(stepValue, 10);
-        return Number.isNaN(parsed) ? null : parsed;
-      }
+    if (isCatchupStep) {
+      const catchupMessage = status?.result.sync_info.catching_up
+        ? 'Node is stuck replaying blocks due to consensus catch-up issues'
+        : 'Consensus step indicates catch-up mode despite sync being reported complete';
+      consensusHealth.issues.push(catchupMessage);
+    }
 
-      return null;
-    })();
+    const stepNumber = stepInfo.number;
 
     if (status) {
       const latestBlockHeight = parseInt(status.result.sync_info.latest_block_height, 10);


### PR DESCRIPTION
## Summary
- normalize consensus step codes to their textual labels when deriving node health
- ensure catch-up consensus states are detected even when RPC responses use numeric step identifiers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcdb6df5dc8320b65cf4729c2b0571