### PR TITLE
Remove governance and wallet sections from dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ A modern, real-time dashboard for monitoring CometBFT 0.38.12 node health and st
 - **Network Information**: Network ID, peer count, validator status, and connectivity
 - **Consensus State**: Height, round, step progression, and prevote/precommit participation
 - **Consensus Stall Detection**: Flags catch-up loops reported by `/dump_consensus_state` so operators can spot replay issues early
-- **Governance Proposals**: Paginated masternode proposals with live yes/no tallies, voter lists, and manual refresh support
 - **Health & Alerts**: Active issue detection, system status, and error monitoring
 - **Mempool Activity**: Pending transactions, queue depth, and recent transaction previews
 
@@ -132,19 +131,6 @@ The dashboard connects to these CometBFT REST API endpoints:
 | `/unconfirmed_txs` | Mempool backlog | Pending transactions and queue size |
 | `/dump_consensus_state` | Consensus progress | Height, round, step, vote participation |
 | `/health` | Node health check | Overall health status |
-| `/abci_query?path="/get/masternodes.total_votes"` | Governance totals | Total number of proposals available |
-| `/abci_query?path="/get/masternodes.votes:{id}"` | Governance proposal detail | Proposal type, arguments, vote counts, and voter addresses |
-
-## 🗳️ Governance Monitoring
-
-Validator nodes gain access to a detailed governance dashboard that complements the existing consensus metrics:
-
-- **Responsive proposal explorer** that adapts between a sortable table on desktop and stacked cards on mobile
-- **Per-proposal insights** covering type, decoded argument payloads, yes/no tallies, finalized status, and full voter breakdowns
-- **Pagination controls** to browse the full proposal history without overloading the node
-- **Manual refresh** to immediately pull in new proposals or votes when needed
-
-If the connected node is not acting as a validator, the UI surfaces helpful guidance instead of attempting unsupported queries.
 
 ## 🏗️ Project Structure
 
@@ -160,13 +146,11 @@ node-dashboard/
 │   │   ├── LoadingSpinner.tsx   # Loading component
 │   │   ├── MempoolCard.tsx      # Mempool overview
 │   │   ├── NetworkInfoCard.tsx  # Network connectivity
-│   │   ├── GovernanceCard.tsx   # Validator governance overview
 │   │   ├── NodeStatusCard.tsx   # Sync state and block height
 │   │   ├── StatusIndicator.tsx  # Shared status badge
 │   │   └── VersionInfoCard.tsx  # Version metadata
 │   ├── hooks/                   # Custom React hooks
-│   │   ├── useCometStatus.ts    # Status polling
-│   │   └── useGovernance.ts     # Governance proposal pagination and refresh logic
+│   │   └── useCometStatus.ts    # Status polling
 │   ├── services/                # API services
 │   │   └── cometbft.ts          # CometBFT API client
 │   ├── types/                   # TypeScript definitions
@@ -212,12 +196,6 @@ Main dashboard layout with responsive grid system for monitoring cards.
 - Validator status
 - Network connectivity health
 
-#### `GovernanceCard.tsx`
-- Validator-only governance proposal overview
-- Paginated yes/no vote tallies with finalization status
-- Decoded proposal arguments with JSON fallback rendering
-- Detailed voter lists with monospace formatting for addresses
-
 #### `ConsensusStateCard.tsx`
 - Consensus height, round, and step tracking
 - Prevote and precommit participation ratios
@@ -257,7 +235,6 @@ Centralized API service for all CometBFT REST API interactions:
 - Prevote and precommit participation ratios
 - Peer connection count
 - Network participation status
-- Governance proposal counts and vote tallies
 - API response times
 
 ### Error Detection
@@ -266,7 +243,6 @@ Centralized API service for all CometBFT REST API interactions:
 - Sync lag detection
 - Peer connectivity problems
 - Version compatibility checks
-- Governance query failures or validator misconfiguration
 
 ## 🚨 Troubleshooting
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -7,12 +7,9 @@ import { NetworkInfoCard } from './NetworkInfoCard';
 import { MempoolCard } from './MempoolCard';
 import { VersionInfoCard } from './VersionInfoCard';
 import { useCometBFT } from '../hooks/useCometBFT';
-import { useGovernance } from '../hooks/useGovernance';
-import { GovernanceCard } from './GovernanceCard';
-import { useWallet } from '../hooks/useWallet';
 import { buildNodeConnection, DEFAULT_NODE_ADDRESS } from '../utils/nodeConnection';
 
-type DashboardTab = 'overview' | 'health' | 'network' | 'governance';
+type DashboardTab = 'overview' | 'health' | 'network';
 
 export function Dashboard() {
   const [nodeInput, setNodeInput] = useState(DEFAULT_NODE_ADDRESS);
@@ -24,18 +21,6 @@ export function Dashboard() {
     autoRefresh: true,
     consensusRefreshInterval: 1000,
     enableConsensusRealtime: true
-  });
-
-  const wallet = useWallet();
-
-  const validatorInfo = data.status?.result.validator_info;
-  const votingPower = validatorInfo ? Number(validatorInfo.voting_power) : 0;
-  const isValidator = Number.isFinite(votingPower) && votingPower > 0;
-
-  const governance = useGovernance({
-    nodeUrl: nodeConnection.baseUrl,
-    enabled: isValidator,
-    pageSize: 5,
   });
 
   const handleNodeUrlChange = (value: string) => {
@@ -58,11 +43,6 @@ export function Dashboard() {
       label: 'Network activity',
       description: 'Peer connectivity, throughput and mempool insights',
     },
-    {
-      id: 'governance',
-      label: 'Governance',
-      description: 'Validator decision tracking',
-    },
   ];
 
   return (
@@ -72,11 +52,6 @@ export function Dashboard() {
         nodeRpcUrl={nodeConnection.rpcUrl}
         isUsingProxy={nodeConnection.usesProxy}
         onNodeAddressChange={handleNodeUrlChange}
-        walletInfo={wallet.walletInfo}
-        isConnectingWallet={wallet.isConnecting}
-        onConnectWallet={wallet.connect}
-        walletError={wallet.error}
-        onClearWalletError={wallet.clearError}
       />
 
       <main className="dashboard-content">
@@ -177,34 +152,6 @@ export function Dashboard() {
           </section>
         )}
 
-        {activeTab === 'governance' && (
-          <section
-            className="dashboard-section"
-            role="tabpanel"
-            id="dashboard-panel-governance"
-            aria-labelledby="dashboard-tab-governance"
-          >
-            <div className="dashboard-section__header">
-              <h2 className="dashboard-section__title">Governance</h2>
-              <p className="dashboard-section__subtitle">
-                Validator decision tracking
-              </p>
-            </div>
-            <div className="dashboard-grid">
-              <div className="dashboard-item dashboard-item--wide">
-                <GovernanceCard
-                  isValidator={isValidator}
-                  governance={governance}
-                  walletInfo={wallet.walletInfo}
-                  isConnectingWallet={wallet.isConnecting}
-                  onConnectWallet={wallet.connect}
-                  walletError={wallet.error}
-                  clearWalletError={wallet.clearError}
-                />
-              </div>
-            </div>
-          </section>
-        )}
       </main>
 
       <footer className="dashboard-footer">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,18 +1,11 @@
 import { useEffect, useState, FormEvent } from 'react';
-import { LoadingSpinner } from './LoadingSpinner';
-import { CometBFTLogo, PencilIcon, WalletIcon, XIcon } from './Icons';
-import { ConnectedWalletInfo } from '../hooks/useWallet';
+import { CometBFTLogo, PencilIcon } from './Icons';
 
 interface HeaderProps {
   nodeAddress: string;
   nodeRpcUrl: string;
   isUsingProxy: boolean;
   onNodeAddressChange: (value: string) => void;
-  walletInfo: ConnectedWalletInfo | null;
-  isConnectingWallet: boolean;
-  onConnectWallet: () => void;
-  walletError: string | null;
-  onClearWalletError: () => void;
 }
 
 export function Header({
@@ -20,11 +13,6 @@ export function Header({
   nodeRpcUrl,
   isUsingProxy,
   onNodeAddressChange,
-  walletInfo,
-  isConnectingWallet,
-  onConnectWallet,
-  walletError,
-  onClearWalletError,
 }: HeaderProps) {
   const [nodeUrl, setNodeUrl] = useState(nodeAddress);
   const [isEditing, setIsEditing] = useState(false);
@@ -34,11 +22,6 @@ export function Header({
       setNodeUrl(nodeAddress);
     }
   }, [nodeAddress, isEditing]);
-
-  const walletDisplayAddress = walletInfo?.truncatedAddress
-    ?? (walletInfo?.address
-      ? `${walletInfo.address.slice(0, 6)}…${walletInfo.address.slice(-4)}`
-      : null);
 
   const handleUrlSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -106,9 +89,19 @@ export function Header({
         </div>
 
         {/* Node URL Configuration */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'flex-end',
+            gap: 'var(--space-3)',
+            flexDirection: isEditing ? 'column' : 'row',
+          }}
+        >
           {isEditing ? (
-            <form onSubmit={handleUrlSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <form
+              onSubmit={handleUrlSubmit}
+              style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}
+            >
               <input
                 type="text"
                 value={nodeUrl}
@@ -160,16 +153,38 @@ export function Header({
                   Cancel
                 </button>
               </div>
-              <p style={{
-                margin: 0,
-                fontSize: 'var(--text-xs)',
-                color: 'var(--text-muted)'
-              }}>
-                RPC port 26657 is appended automatically{isUsingProxy ? ' and HTTP endpoints are proxied to keep the dashboard secure.' : '.'}
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: 'var(--text-xs)',
+                  color: 'var(--text-muted)'
+                }}
+              >
+                RPC port 26657 is appended automatically
+                {isUsingProxy
+                  ? ' and HTTP endpoints are proxied to keep the dashboard secure.'
+                  : '.'}
+              </p>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: 'var(--text-xs)',
+                  color: 'var(--text-muted)',
+                  fontFamily: 'var(--font-mono)'
+                }}
+              >
+                Current endpoint: {nodeRpcUrl}
               </p>
             </form>
           ) : (
-            <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 'var(--space-2)',
+                flexDirection: 'column'
+              }}
+            >
               <span style={{
                 fontSize: 'var(--text-sm)',
                 color: 'var(--text-muted)'
@@ -202,89 +217,17 @@ export function Header({
                 <PencilIcon size={14} style={{ flexShrink: 0 }} />
                 {nodeAddress || 'Configure node'}
               </button>
+              <span
+                style={{
+                  fontSize: 'var(--text-xs)',
+                  color: 'var(--text-muted)',
+                  fontFamily: 'var(--font-mono)'
+                }}
+              >
+                RPC endpoint: {nodeRpcUrl}
+              </span>
             </div>
           )}
-        </div>
-
-        {/* Wallet Controls */}
-        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 'var(--space-2)' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
-            <div style={{ textAlign: 'right' }}>
-              <span style={{ display: 'block', fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
-                Wallet status
-              </span>
-              <span style={{ fontSize: 'var(--text-sm)', color: walletInfo ? 'var(--text-secondary)' : 'var(--text-muted)', fontFamily: walletInfo ? 'var(--font-mono)' : 'inherit' }}>
-                {walletInfo ? walletDisplayAddress : 'Not connected'}
-              </span>
-              {walletInfo?.locked ? (
-                <span style={{ display: 'block', fontSize: 'var(--text-xs)', color: 'var(--color-warning)' }}>
-                  Wallet is locked
-                </span>
-              ) : null}
-            </div>
-            <button
-              type="button"
-              onClick={onConnectWallet}
-              disabled={isConnectingWallet}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 'var(--space-2)',
-                padding: 'var(--space-3) var(--space-4)',
-                background: 'var(--primary-gradient)',
-                border: 'none',
-                borderRadius: 'var(--radius-lg)',
-                color: 'white',
-                fontSize: 'var(--text-sm)',
-                fontWeight: 'var(--font-medium)',
-                cursor: isConnectingWallet ? 'not-allowed' : 'pointer',
-                transition: 'var(--transition-fast)',
-                opacity: isConnectingWallet ? 0.7 : 1,
-              }}
-            >
-              {isConnectingWallet ? (
-                <>
-                  <LoadingSpinner size="sm" />
-                  Connecting…
-                </>
-              ) : (
-                <>
-                  <WalletIcon size={16} />
-                  {walletInfo ? 'Reconnect Wallet' : 'Connect Wallet'}
-                </>
-              )}
-            </button>
-          </div>
-          {walletError ? (
-            <div style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--space-2)',
-              background: 'rgba(255, 71, 87, 0.12)',
-              color: 'var(--color-error)',
-              borderRadius: 'var(--radius-md)',
-              padding: 'var(--space-2) var(--space-3)',
-              fontSize: 'var(--text-xs)',
-            }}>
-              <span>{walletError}</span>
-              <button
-                type="button"
-                onClick={onClearWalletError}
-                style={{
-                  border: 'none',
-                  background: 'transparent',
-                  color: 'inherit',
-                  display: 'flex',
-                  alignItems: 'center',
-                  cursor: 'pointer',
-                  padding: 0,
-                }}
-                aria-label="Dismiss wallet error"
-              >
-                <XIcon size={12} />
-              </button>
-            </div>
-          ) : null}
         </div>
       </div>
     </header>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
-import XianWalletUtils from './services/xianWalletUtils';
-
-XianWalletUtils.init();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/services/cometbft.ts
+++ b/src/services/cometbft.ts
@@ -520,7 +520,6 @@ export class CometBFTService {
 
   private analyzeNodeHealth(
     status: StatusResponse | null,
-    netInfo: NetInfoResponse | null,
     consensusState: ConsensusStateResponse | null,
     abciInfo: ABCIInfoResponse | null,
     commit: CommitResponse | null,
@@ -727,7 +726,6 @@ export class CometBFTService {
       // Analyze health
       data.health = this.analyzeNodeHealth(
         data.status,
-        data.netInfo,
         data.consensusState,
         data.abciInfo,
         data.commit,


### PR DESCRIPTION
## Summary
- remove the governance tab and wallet controls from the dashboard layout
- simplify the header to focus on node configuration details and drop wallet dependencies
- adjust the header layout so the RPC endpoint is displayed with the node configuration instead of a third column

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd50f6629883209c842cad5c623520