### PR TITLE
Add GraphQL availability badge to node status

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -20,7 +20,8 @@ export function Dashboard() {
     refreshInterval: 5000,
     autoRefresh: true,
     consensusRefreshInterval: 1000,
-    enableConsensusRealtime: true
+    enableConsensusRealtime: true,
+    graphqlProbeUrl: nodeConnection.graphqlProbeUrl,
   });
 
   const handleNodeUrlChange = (value: string) => {

--- a/src/components/NodeStatusCard.tsx
+++ b/src/components/NodeStatusCard.tsx
@@ -43,6 +43,28 @@ export function NodeStatusCard({ data }: NodeStatusCardProps) {
   const isSynced = !sync_info.catching_up;
   const votingPower = Number(validator_info.voting_power);
   const isValidator = Number.isFinite(votingPower) && votingPower > 0;
+  const graphqlEnabled = data.health.graphqlEnabled;
+
+  const graphqlStatus = (() => {
+    if (graphqlEnabled === true) {
+      return {
+        variant: 'success' as const,
+        label: 'GraphQL Enabled',
+      };
+    }
+
+    if (graphqlEnabled === false) {
+      return {
+        variant: 'error' as const,
+        label: 'GraphQL Unreachable',
+      };
+    }
+
+    return {
+      variant: 'warning' as const,
+      label: 'GraphQL Unknown',
+    };
+  })();
 
   return (
     <Card title="Node Status" glow={data.health.isOnline}>
@@ -69,7 +91,14 @@ export function NodeStatusCard({ data }: NodeStatusCardProps) {
             <StatusIndicator status={isValidator ? 'success' : 'warning'}>
               {isValidator ? 'Validator Active' : 'Not in Validator Set'}
             </StatusIndicator>
-            
+
+          </div>
+
+          {/* GraphQL Availability */}
+          <div>
+            <StatusIndicator status={graphqlStatus.variant}>
+              {graphqlStatus.label}
+            </StatusIndicator>
           </div>
         </div>
 

--- a/src/hooks/useCometBFT.ts
+++ b/src/hooks/useCometBFT.ts
@@ -8,6 +8,7 @@ interface UseCometBFTOptions {
   nodeUrl?: string;
   consensusRefreshInterval?: number;
   enableConsensusRealtime?: boolean;
+  graphqlProbeUrl?: string | null;
 }
 
 export function useCometBFT(options: UseCometBFTOptions = {}) {
@@ -16,7 +17,8 @@ export function useCometBFT(options: UseCometBFTOptions = {}) {
     autoRefresh = true,
     nodeUrl,
     consensusRefreshInterval = 1000,
-    enableConsensusRealtime = true
+    enableConsensusRealtime = true,
+    graphqlProbeUrl = null,
   } = options;
 
   const [data, setData] = useState<DashboardData>({
@@ -41,6 +43,7 @@ export function useCometBFT(options: UseCometBFTOptions = {}) {
         precommitRatio: null,
         issues: [],
       },
+      graphqlEnabled: null,
     },
     loading: true,
     error: null,
@@ -55,7 +58,8 @@ export function useCometBFT(options: UseCometBFTOptions = {}) {
     if (nodeUrl) {
       cometbftService.setBaseUrl(nodeUrl);
     }
-  }, [nodeUrl]);
+    cometbftService.setGraphqlProbeUrl(graphqlProbeUrl ?? null);
+  }, [nodeUrl, graphqlProbeUrl]);
 
   const fetchData = useCallback(async () => {
     try {
@@ -125,6 +129,7 @@ export function useCometBFT(options: UseCometBFTOptions = {}) {
             precommitRatio: null,
             issues: [error instanceof Error ? error.message : 'Failed to fetch data'],
           },
+          graphqlEnabled: null,
         },
         consensusHistory: prev.consensusHistory,
       }));

--- a/src/types/cometbft.ts
+++ b/src/types/cometbft.ts
@@ -285,6 +285,7 @@ export interface NodeHealth {
   errorMessages: string[];
   lastUpdated: Date;
   consensus: ConsensusHealth;
+  graphqlEnabled: boolean | null;
 }
 
 export type GovernanceArgument =

--- a/src/utils/nodeConnection.ts
+++ b/src/utils/nodeConnection.ts
@@ -38,6 +38,10 @@ export interface NodeConnection {
    * provides a different port.
    */
   port: string;
+  /**
+   * Helper URL that probes the node's GraphQL endpoint via the proxy service.
+   */
+  graphqlProbeUrl: string;
 }
 
 const PROTOCOL_PATTERN = /^[a-zA-Z][a-zA-Z+.-]*:\/\//;
@@ -113,6 +117,10 @@ export function buildNodeConnection(rawInput: string): NodeConnection {
   const usesProxy = protocol === 'http:';
   const baseUrl = usesProxy ? `${HTTP_PROXY_PREFIX}${rpcUrl}` : rpcUrl;
 
+  const graphqlHostname = normaliseHostname(hostname || DEFAULT_NODE_ADDRESS);
+  const graphqlTarget = `https://${graphqlHostname}/graphiql`;
+  const graphqlProbeUrl = `${HTTP_PROXY_PREFIX}${graphqlTarget}`;
+
   const cleanedInput = (() => {
     const rawHostname = stripHostnameBrackets(hostname) || DEFAULT_NODE_ADDRESS;
     const hasCustomPort = Boolean(parsed.port && parsed.port !== DEFAULT_RPC_PORT);
@@ -133,6 +141,7 @@ export function buildNodeConnection(rawInput: string): NodeConnection {
     protocol,
     hostname: stripHostnameBrackets(hostname),
     port,
+    graphqlProbeUrl,
   };
 }
 


### PR DESCRIPTION
## Summary
- surface GraphQL availability on the node status card with a dedicated badge
- probe the node's GraphQL endpoint via the proxy and propagate the result through the dashboard data flow
- extend node connection details to include a prebuilt GraphQL probe URL for downstream consumers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68dd6357c3888320944678e8b7b23256